### PR TITLE
Add specialty analysis for OF 2025 dataset

### DIFF
--- a/analysis_outputs/specialites_analysis.md
+++ b/analysis_outputs/specialites_analysis.md
@@ -1,0 +1,168 @@
+# Analyse des spécialités OF France 2025
+
+## Tableau 1 : Top 50 des spécialités principales (Spé 1)
+| Rang | Code NSF | Libellé spécialité | OF total | % base | OF TAM | % TAM |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 333.0 | Enseignement, formation | 10 897 | 7.1% | 1 443 | 11.7% |
+| 2 | 326.0 | Informatique, traitement de l'information, réseaux de transmission des données | 9 462 | 6.1% | 747 | 6.1% |
+| 3 | 100.0 | Formations générales | 9 200 | 6.0% | 1 248 | 10.1% |
+| 4 | 999.0 | Autres... | 9 137 | 5.9% | 411 | 3.3% |
+| 5 | 312.0 | Commerce, vente | 8 267 | 5.4% | 555 | 4.5% |
+| 6 | 413.0 | Développement des capacités comportementales et relationnelles | 7 297 | 4.7% | 544 | 4.4% |
+| 7 | 331.0 | Santé | 6 923 | 4.5% | 617 | 5.0% |
+| 8 | 136.0 | Langues vivantes, civilisations étrangères et régionales | 6 112 | 4.0% | 330 | 2.7% |
+| 9 | 315.0 | Ressources humaines, gestion du personnel, gestion de l'emploi | 6 007 | 3.9% | 451 | 3.7% |
+| 10 | 336.0 | Coiffure, esthétique et autres spécialités des services aux personnes | 4 260 | 2.8% | 210 | 1.7% |
+| 11 | 314.0 | Comptabilité, gestion | 3 659 | 2.4% | 307 | 2.5% |
+| 12 | 415.0 | Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles | 3 249 | 2.1% | 186 | 1.5% |
+| 13 | 344.0 | Sécurité des biens et des personnes, police, surveillance | 3 180 | 2.1% | 366 | 3.0% |
+| 14 | 311.0 | Transport, manutention, magasinage | 3 087 | 2.0% | 625 | 5.1% |
+| 15 | 128.0 | Droit, sciences politiques | 2 856 | 1.9% | 166 | 1.3% |
+| 16 | 320.0 | Spécialités plurivalentes de la communication | 2 646 | 1.7% | 142 | 1.2% |
+| 17 | 310.0 | Spécialités plurivalentes des échanges et de la gestion | 2 312 | 1.5% | 225 | 1.8% |
+| 18 | 221.0 | Agro-alimentaire, alimentation, cuisine | 2 092 | 1.4% | 243 | 2.0% |
+| 19 | 313.0 | Finances, banque, assurances | 2 060 | 1.3% | 89 | 0.7% |
+| 20 | 125.0 | Linguistique | 2 055 | 1.3% | 186 | 1.5% |
+| 21 | 324.0 | Secrétariat, bureautique | 2 016 | 1.3% | 99 | 0.8% |
+| 22 | 124.0 | Psychologie | 1 986 | 1.3% | 96 | 0.8% |
+| 23 | 321.0 | Journalisme et communication | 1 904 | 1.2% | 59 | 0.5% |
+| 24 | 332.0 | Travail social | 1 814 | 1.2% | 131 | 1.1% |
+| 25 | 330.0 | Spécialités plurivalentes sanitaires et sociales | 1 788 | 1.2% | 207 | 1.7% |
+| 26 | 300.0 | Spécialités plurivalentes des services | 1 767 | 1.1% | 161 | 1.3% |
+| 27 | 131.0 | Français, littérature et civilisation françaises | 1 310 | 0.9% | 72 | 0.6% |
+| 28 | 134.0 | Autres disciplines artistiques et spécialités artistiques plurivalentes | 1 283 | 0.8% | 82 | 0.7% |
+| 29 | 255.0 | Electricité, électronique (non compris automatisme et productique) | 1 238 | 0.8% | 102 | 0.8% |
+| 30 | 411.0 | Pratiques sportives | 1 222 | 0.8% | 106 | 0.9% |
+| 31 | 414.0 | Développement des capacités individuelles d'organisation | 1 138 | 0.7% | 49 | 0.4% |
+| 32 | 323.0 | Techniques de l'image et du son, métiers connexes du spectacle | 1 064 | 0.7% | 70 | 0.6% |
+| 33 | 335.0 | Animation culturelle, sportive et de loisirs | 1 014 | 0.7% | 137 | 1.1% |
+| 34 | 120.0 | Spécialités pluridisciplinaires, sciences humaines et droit | 1 010 | 0.7% | 94 | 0.8% |
+| 35 | 133.0 | Musique, arts du spectacle | 1 000 | 0.6% | 117 | 1.0% |
+| 36 | 410.0 | Spécialités concernant plusieurs capacités | 936 | 0.6% | 70 | 0.6% |
+| 37 | 232.0 | Bâtiment: construction et couverture | 851 | 0.6% | 92 | 0.7% |
+| 38 | 122.0 | Economie | 842 | 0.5% | 12 | 0.1% |
+| 39 | 423.0 | Vie familiale, vie sociale et autres formations au développement personnel | 825 | 0.5% | 35 | 0.3% |
+| 40 | 227.0 | Energie, génie climatique | 816 | 0.5% | 97 | 0.8% |
+| 41 | 334.0 | Accueil, hôtellerie, tourisme | 765 | 0.5% | 40 | 0.3% |
+| 42 | 212.0 | Productions animales, élevage spécialisé, aquaculture, ... | 703 | 0.5% | 74 | 0.6% |
+| 43 | 200.0 | Technologies industrielles fondamentales | 691 | 0.4% | 71 | 0.6% |
+| 44 | 201.0 | Technologies de commandes des transformations industrielles | 676 | 0.4% | 133 | 1.1% |
+| 45 | 210.0 | Spécialités plurivalentes de l'agronomie et de l'agriculture | 674 | 0.4% | 68 | 0.6% |
+| 46 | 412.0 | Développement des capacités mentales et apprentissages de base | 590 | 0.4% | 42 | 0.3% |
+| 47 | 110.0 | Spécialités pluriscientifiques | 589 | 0.4% | 45 | 0.4% |
+| 48 | 123.0 | Sciences sociales (y compris démographie, anthropologie) | 559 | 0.4% | 24 | 0.2% |
+| 49 | 132.0 | Arts plastiques | 538 | 0.3% | 22 | 0.2% |
+| 50 | 211.0 | Productions végétales,cultures spécialisées | 534 | 0.3% | 69 | 0.6% |
+
+## Tableau 2 : Répartition par macro-thème
+| Macro-thème | OF total | % base | OF TAM | % TAM | Stag. moyen (TAM) | Spés principales |
+| --- | --- | --- | --- | --- | --- | --- |
+| Autre | 42 238 | 27.4% | 3 242 | 26.4% | 230.9 | Formations générales, Autres..., Agro-alimentaire, alimentation, cuisine |
+| Soft Skills | 27 450 | 17.8% | 2 624 | 21.3% | 283.1 | Enseignement, formation, Développement des capacités comportementales et relationnelles, Ressources humaines, gestion du personnel, gestion de l'emploi |
+| Services | 14 664 | 9.5% | 1 429 | 11.6% | 263.8 | Transport, manutention, magasinage, Coiffure, esthétique et autres spécialités des services aux personnes, Spécialités plurivalentes des services |
+| Commerce/Gestion | 16 298 | 10.6% | 1 176 | 9.6% | 271.9 | Commerce, vente, Comptabilité, gestion, Spécialités plurivalentes des échanges et de la gestion |
+| Santé | 12 014 | 7.8% | 1 025 | 8.3% | 283.7 | Santé, Spécialités plurivalentes sanitaires et sociales, Travail social |
+| Industrie | 7 299 | 4.7% | 893 | 7.3% | 240.3 | Technologies de commandes des transformations industrielles, Energie, génie climatique, Bâtiment: construction et couverture |
+| Tech/Digital | 9 595 | 6.2% | 758 | 6.2% | 220.4 | Informatique, traitement de l'information, réseaux de transmission des données, Documentation, bibliothèques, administration des données |
+| Langues | 8 232 | 5.3% | 522 | 4.2% | 181.8 | Langues vivantes, civilisations étrangères et régionales, Linguistique, Langues et civilisations anciennes |
+| Sécurité | 3 180 | 2.1% | 366 | 3.0% | 663.1 | Sécurité des biens et des personnes, police, surveillance |
+| Juridique | 3 936 | 2.6% | 268 | 2.2% | 283.6 | Droit, sciences politiques, Spécialités pluridisciplinaires, sciences humaines et droit, Application des droits et statuts des personnes |
+
+## Tableau 3a : Top 20 spécialités secondaires (Spé 2)
+| Rang | Libellé spécialité | OF avec Spé2 | % des 29 778 |
+| --- | --- | --- | --- |
+| 1 | Autres... | 2 429 | 8.2% |
+| 2 | Développement des capacités comportementales et relationnelles | 2 111 | 7.1% |
+| 3 | Enseignement, formation | 2 003 | 6.7% |
+| 4 | Ressources humaines, gestion du personnel, gestion de l'emploi | 1 980 | 6.6% |
+| 5 | Commerce, vente | 1 746 | 5.9% |
+| 6 | Informatique, traitement de l'information, réseaux de transmission des données | 1 596 | 5.4% |
+| 7 | Comptabilité, gestion | 1 247 | 4.2% |
+| 8 | Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles | 1 190 | 4.0% |
+| 9 | Santé | 957 | 3.2% |
+| 10 | Sécurité des biens et des personnes, police, surveillance | 940 | 3.2% |
+| 11 | Secrétariat, bureautique | 793 | 2.7% |
+| 12 | Développement des capacités individuelles d'organisation | 685 | 2.3% |
+| 13 | Spécialités plurivalentes de la communication | 636 | 2.1% |
+| 14 | Langues vivantes, civilisations étrangères et régionales | 603 | 2.0% |
+| 15 | Travail social | 564 | 1.9% |
+| 16 | Transport, manutention, magasinage | 539 | 1.8% |
+| 17 | Spécialités plurivalentes des échanges et de la gestion | 487 | 1.6% |
+| 18 | Finances, banque, assurances | 479 | 1.6% |
+| 19 | Journalisme et communication | 455 | 1.5% |
+| 20 | Coiffure, esthétique et autres spécialités des services aux personnes | 415 | 1.4% |
+
+## Tableau 3b : Top 20 spécialités tertiaires (Spé 3)
+| Rang | Libellé spécialité | OF avec Spé3 | % des 12 642 |
+| --- | --- | --- | --- |
+| 1 | Développement des capacités comportementales et relationnelles | 1 020 | 8.1% |
+| 2 | Autres... | 882 | 7.0% |
+| 3 | Ressources humaines, gestion du personnel, gestion de l'emploi | 861 | 6.8% |
+| 4 | Informatique, traitement de l'information, réseaux de transmission des données | 784 | 6.2% |
+| 5 | Enseignement, formation | 664 | 5.3% |
+| 6 | Comptabilité, gestion | 596 | 4.7% |
+| 7 | Développement des capacités individuelles d'organisation | 567 | 4.5% |
+| 8 | Commerce, vente | 558 | 4.4% |
+| 9 | Sécurité des biens et des personnes, police, surveillance | 527 | 4.2% |
+| 10 | Secrétariat, bureautique | 510 | 4.0% |
+| 11 | Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles | 505 | 4.0% |
+| 12 | Spécialités plurivalentes de la communication | 333 | 2.6% |
+| 13 | Santé | 333 | 2.6% |
+| 14 | Transport, manutention, magasinage | 296 | 2.3% |
+| 15 | Travail social | 261 | 2.1% |
+| 16 | Spécialités plurivalentes sanitaires et sociales | 217 | 1.7% |
+| 17 | Finances, banque, assurances | 197 | 1.6% |
+| 18 | Vie familiale, vie sociale et autres formations au développement personnel | 191 | 1.5% |
+| 19 | Accueil, hôtellerie, tourisme | 188 | 1.5% |
+| 20 | Electricité, électronique (non compris automatisme et productique) | 176 | 1.4% |
+
+## Tableau 4 : TAM qualifié par macro-thème
+| Macro-thème | OF TAM | % TAM | Stag. moyen | Prod est. | Priorité |
+| --- | --- | --- | --- | --- | --- |
+| Autre | 3 242 | 26.4% | 230.9 | 43.20 | MOYENNE |
+| Soft Skills | 2 624 | 21.3% | 283.1 | 53.90 | HAUTE |
+| Services | 1 429 | 11.6% | 263.8 | 48.77 | MOYENNE |
+| Commerce/Gestion | 1 176 | 9.6% | 271.9 | 51.00 | BASSE |
+| Santé | 1 025 | 8.3% | 283.7 | 52.15 | BASSE |
+| Industrie | 893 | 7.3% | 240.3 | 44.72 | BASSE |
+| Tech/Digital | 758 | 6.2% | 220.4 | 40.76 | BASSE |
+| Langues | 522 | 4.2% | 181.8 | 34.92 | BASSE |
+| Sécurité | 366 | 3.0% | 663.1 | 117.94 | BASSE |
+| Juridique | 268 | 2.2% | 283.6 | 48.73 | BASSE |
+
+## Tableau 5 : Niches sur-représentées dans le TAM
+| Spécialité | OF base | % base | OF TAM | % TAM | Ratio TAM/base |
+| --- | --- | --- | --- | --- | --- |
+| Aucune spécialité | - | - | - | - | - |
+
+## Tableau 6 : Diversité des spécialités par région
+| Région | Nb spés différentes | Spé dominante | % spé dominante | Diversité |
+| --- | --- | --- | --- | --- |
+| Autres DOM-TOM | 7 | Commerce, vente | 14.3% | Forte |
+| Auvergne-Rhône-Alpes | 94 | Enseignement, formation | 6.9% | Forte |
+| Bourgogne-Franche-Comté | 91 | Enseignement, formation | 7.6% | Forte |
+| Bretagne | 94 | Enseignement, formation | 7.3% | Forte |
+| Centre-Val de Loire | 90 | Enseignement, formation | 8.4% | Forte |
+| Corse | 58 | Enseignement, formation | 9.0% | Forte |
+| Grand Est | 92 | Enseignement, formation | 8.1% | Forte |
+| Guadeloupe | 72 | Formations générales | 10.0% | Forte |
+| Guyane | 65 | Formations générales | 12.2% | Forte |
+| Hauts-de-France | 91 | Enseignement, formation | 8.2% | Forte |
+| La Réunion | 84 | Commerce, vente | 8.9% | Forte |
+| Martinique | 69 | Formations générales | 8.2% | Forte |
+| Mayotte | 42 | Formations générales | 14.8% | Forte |
+| Normandie | 90 | Enseignement, formation | 8.0% | Forte |
+| Nouvelle-Aquitaine | 94 | Enseignement, formation | 7.3% | Forte |
+| Occitanie | 94 | Enseignement, formation | 7.4% | Forte |
+| Pays de la Loire | 93 | Informatique, traitement de l'information, réseaux de transmission des données | 6.9% | Forte |
+| Provence-Alpes-Côte d'Azur | 92 | Enseignement, formation | 7.5% | Forte |
+| Île-de-France | 94 | Informatique, traitement de l'information, réseaux de transmission des données | 8.0% | Forte |
+
+## Synthèse
+Spé 1 : 144 906 OF renseignés (94.0%).
+Spé 2 : 29 778 OF (19.3%).
+Spé 3 : 12 642 OF (8.2%).
+
+Top 5 spécialités : Enseignement, formation : 10 897 OF (7.1% base, 11.7% TAM), Informatique, traitement de l'information, réseaux de transmission des données : 9 462 OF (6.1% base, 6.1% TAM), Formations générales : 9 200 OF (6.0% base, 10.1% TAM), Autres... : 9 137 OF (5.9% base, 3.3% TAM), Commerce, vente : 8 267 OF (5.4% base, 4.5% TAM).
+Macro-thèmes prioritaires : 1. Autre : 26.4% TAM, 2. Soft Skills : 21.3% TAM, 3. Services : 11.6% TAM.
+Niches émergentes : aucune spécialité sur-représentée.

--- a/analysis_outputs/specialites_export.csv
+++ b/analysis_outputs/specialites_export.csv
@@ -1,0 +1,61 @@
+table,rang,code,label,of_total,pct_base,of_tam,pct_tam,extra
+top50,1,333.0,"Enseignement, formation",10897,7.07,1443,11.73,
+top50,2,326.0,"Informatique, traitement de l'information, réseaux de transmission des données",9462,6.14,747,6.07,
+top50,3,100.0,Formations générales,9200,5.97,1248,10.14,
+top50,4,999.0,Autres...,9137,5.93,411,3.34,
+top50,5,312.0,"Commerce, vente",8267,5.36,555,4.51,
+top50,6,413.0,Développement des capacités comportementales et relationnelles,7297,4.74,544,4.42,
+top50,7,331.0,Santé,6923,4.49,617,5.02,
+top50,8,136.0,"Langues vivantes, civilisations étrangères et régionales",6112,3.97,330,2.68,
+top50,9,315.0,"Ressources humaines, gestion du personnel, gestion de l'emploi",6007,3.9,451,3.67,
+top50,10,336.0,"Coiffure, esthétique et autres spécialités des services aux personnes",4260,2.76,210,1.71,
+top50,11,314.0,"Comptabilité, gestion",3659,2.37,307,2.5,
+top50,12,415.0,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",3249,2.11,186,1.51,
+top50,13,344.0,"Sécurité des biens et des personnes, police, surveillance",3180,2.06,366,2.97,
+top50,14,311.0,"Transport, manutention, magasinage",3087,2.0,625,5.08,
+top50,15,128.0,"Droit, sciences politiques",2856,1.85,166,1.35,
+top50,16,320.0,Spécialités plurivalentes de la communication,2646,1.72,142,1.15,
+top50,17,310.0,Spécialités plurivalentes des échanges et de la gestion,2312,1.5,225,1.83,
+top50,18,221.0,"Agro-alimentaire, alimentation, cuisine",2092,1.36,243,1.98,
+top50,19,313.0,"Finances, banque, assurances",2060,1.34,89,0.72,
+top50,20,125.0,Linguistique,2055,1.33,186,1.51,
+top50,21,324.0,"Secrétariat, bureautique",2016,1.31,99,0.8,
+top50,22,124.0,Psychologie,1986,1.29,96,0.78,
+top50,23,321.0,Journalisme et communication,1904,1.24,59,0.48,
+top50,24,332.0,Travail social,1814,1.18,131,1.06,
+top50,25,330.0,Spécialités plurivalentes sanitaires et sociales,1788,1.16,207,1.68,
+top50,26,300.0,Spécialités plurivalentes des services,1767,1.15,161,1.31,
+top50,27,131.0,"Français, littérature et civilisation françaises",1310,0.85,72,0.59,
+top50,28,134.0,Autres disciplines artistiques et spécialités artistiques plurivalentes,1283,0.83,82,0.67,
+top50,29,255.0,"Electricité, électronique (non compris automatisme et productique)",1238,0.8,102,0.83,
+top50,30,411.0,Pratiques sportives,1222,0.79,106,0.86,
+top50,31,414.0,Développement des capacités individuelles d'organisation,1138,0.74,49,0.4,
+top50,32,323.0,"Techniques de l'image et du son, métiers connexes du spectacle",1064,0.69,70,0.57,
+top50,33,335.0,"Animation culturelle, sportive et de loisirs",1014,0.66,137,1.11,
+top50,34,120.0,"Spécialités pluridisciplinaires, sciences humaines et droit",1010,0.66,94,0.76,
+top50,35,133.0,"Musique, arts du spectacle",1000,0.65,117,0.95,
+top50,36,410.0,Spécialités concernant plusieurs capacités,936,0.61,70,0.57,
+top50,37,232.0,Bâtiment: construction et couverture,851,0.55,92,0.75,
+top50,38,122.0,Economie,842,0.55,12,0.1,
+top50,39,423.0,"Vie familiale, vie sociale et autres formations au développement personnel",825,0.54,35,0.28,
+top50,40,227.0,"Energie, génie climatique",816,0.53,97,0.79,
+top50,41,334.0,"Accueil, hôtellerie, tourisme",765,0.5,40,0.33,
+top50,42,212.0,"Productions animales, élevage spécialisé, aquaculture, ...",703,0.46,74,0.6,
+top50,43,200.0,Technologies industrielles fondamentales,691,0.45,71,0.58,
+top50,44,201.0,Technologies de commandes des transformations industrielles,676,0.44,133,1.08,
+top50,45,210.0,Spécialités plurivalentes de l'agronomie et de l'agriculture,674,0.44,68,0.55,
+top50,46,412.0,Développement des capacités mentales et apprentissages de base,590,0.38,42,0.34,
+top50,47,110.0,Spécialités pluriscientifiques,589,0.38,45,0.37,
+top50,48,123.0,"Sciences sociales (y compris démographie, anthropologie)",559,0.36,24,0.2,
+top50,49,132.0,Arts plastiques,538,0.35,22,0.18,
+top50,50,211.0,"Productions végétales,cultures spécialisées",534,0.35,69,0.56,
+macro_theme,,,Autre,42238,27.41,3242,26.35,230.87
+macro_theme,,,Soft Skills,27450,17.81,2624,21.33,283.06
+macro_theme,,,Services,14664,9.52,1429,11.62,263.85
+macro_theme,,,Commerce/Gestion,16298,10.58,1176,9.56,271.87
+macro_theme,,,Santé,12014,7.8,1025,8.33,283.75
+macro_theme,,,Industrie,7299,4.74,893,7.26,240.29
+macro_theme,,,Tech/Digital,9595,6.23,758,6.16,220.4
+macro_theme,,,Langues,8232,5.34,522,4.24,181.79
+macro_theme,,,Sécurité,3180,2.06,366,2.97,663.09
+macro_theme,,,Juridique,3936,2.55,268,2.18,283.55

--- a/analyze_specialites.py
+++ b/analyze_specialites.py
@@ -1,0 +1,925 @@
+import csv
+import os
+import zipfile
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+XLSX_PATH = "OF 3-10.xlsx"
+OUTPUT_DIR = "analysis_outputs"
+OUTPUT_MARKDOWN = os.path.join(OUTPUT_DIR, "specialites_analysis.md")
+OUTPUT_CSV = os.path.join(OUTPUT_DIR, "specialites_export.csv")
+
+NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+TARGET_MIN = 3
+TARGET_MAX = 10
+
+REGION_NAMES: Dict[int, str] = {
+    11: "Île-de-France",
+    24: "Centre-Val de Loire",
+    27: "Bourgogne-Franche-Comté",
+    28: "Normandie",
+    32: "Hauts-de-France",
+    44: "Grand Est",
+    52: "Pays de la Loire",
+    53: "Bretagne",
+    75: "Nouvelle-Aquitaine",
+    76: "Occitanie",
+    84: "Auvergne-Rhône-Alpes",
+    93: "Provence-Alpes-Côte d'Azur",
+    94: "Corse",
+    1: "Guadeloupe",
+    2: "Martinique",
+    3: "Guyane",
+    4: "La Réunion",
+    6: "Mayotte",
+    975: "Saint-Pierre-et-Miquelon",
+    977: "Saint-Barthélemy",
+    978: "Saint-Martin",
+    986: "Wallis-et-Futuna",
+    987: "Polynésie française",
+    988: "Nouvelle-Calédonie",
+    989: "Îles de Clipperton",
+}
+
+
+@dataclass
+class Record:
+    region_code: Optional[int]
+    effectif: Optional[int]
+    nb_stagiaires: Optional[float]
+    actions_cert: Optional[float]
+    specialites: Tuple[Optional[Tuple[str, str]], Optional[Tuple[str, str]], Optional[Tuple[str, str]]]
+
+    @property
+    def spec1(self) -> Optional[Tuple[str, str]]:
+        return self.specialites[0]
+
+    @property
+    def spec2(self) -> Optional[Tuple[str, str]]:
+        return self.specialites[1]
+
+    @property
+    def spec3(self) -> Optional[Tuple[str, str]]:
+        return self.specialites[2]
+
+
+def ensure_output_dir() -> None:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def load_shared_strings(zf: zipfile.ZipFile) -> List[str]:
+    shared_strings: List[str] = []
+    path = "xl/sharedStrings.xml"
+    if path not in zf.namelist():
+        return shared_strings
+    with zf.open(path) as f:
+        for event, elem in ET.iterparse(f, events=("end",)):
+            if elem.tag == NS + "si":
+                text = "".join(t.text or "" for t in elem.findall('.//' + NS + 't'))
+                shared_strings.append(text)
+                elem.clear()
+    return shared_strings
+
+
+def column_ref_to_index(ref: str) -> int:
+    letters = "".join(ch for ch in ref if ch.isalpha())
+    idx = 0
+    for ch in letters:
+        idx = idx * 26 + (ord(ch) - ord("A") + 1)
+    return idx - 1
+
+
+def get_cell_value(cell: ET.Element, shared_strings: List[str]) -> Optional[str]:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "s":
+        v = cell.find(NS + "v")
+        if v is None or v.text is None:
+            return None
+        return shared_strings[int(v.text)]
+    if cell_type == "inlineStr":
+        is_elem = cell.find(NS + "is")
+        if is_elem is None:
+            return None
+        return "".join(t.text or "" for t in is_elem.findall('.//' + NS + 't'))
+    v = cell.find(NS + "v")
+    if v is None:
+        return None
+    return v.text
+
+
+def parse_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        if "." in text:
+            return int(round(float(text)))
+        return int(text)
+    except ValueError:
+        return None
+
+
+def parse_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def clean_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def load_records() -> List[Record]:
+    records: List[Record] = []
+    with zipfile.ZipFile(XLSX_PATH) as zf:
+        shared_strings = load_shared_strings(zf)
+        with zf.open("xl/worksheets/sheet1.xml") as f:
+            header_map: Dict[int, str] = {}
+            idx_region = idx_effectif = idx_stagiaires = idx_actions = None
+            idx_spec1_code = idx_spec1_label = None
+            idx_spec2_code = idx_spec2_label = None
+            idx_spec3_code = idx_spec3_label = None
+            for event, elem in ET.iterparse(f, events=("end",)):
+                if elem.tag != NS + "row":
+                    continue
+                row_idx = int(elem.attrib.get("r"))
+                if row_idx == 1:
+                    for cell in elem.findall(NS + "c"):
+                        ref = cell.attrib.get("r")
+                        if not ref:
+                            continue
+                        col_idx = column_ref_to_index(ref)
+                        val = get_cell_value(cell, shared_strings)
+                        if val is not None:
+                            header_map[col_idx] = val
+                    idx_region = next((idx for idx, name in header_map.items() if name == "adressePhysiqueOrganismeFormation.codeRegion"), None)
+                    idx_actions = next((idx for idx, name in header_map.items() if name == "certifications.actionsDeFormation"), None)
+                    idx_spec1_code = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.codeSpecialite1"), None)
+                    idx_spec1_label = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.libelleSpecialite1"), None)
+                    idx_spec2_code = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.codeSpecialite2"), None)
+                    idx_spec2_label = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.libelleSpecialite2"), None)
+                    idx_spec3_code = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.codeSpecialite3"), None)
+                    idx_spec3_label = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.specialitesDeFormation.libelleSpecialite3"), None)
+                    idx_stagiaires = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.nbStagiaires"), None)
+                    idx_effectif = next((idx for idx, name in header_map.items() if name == "informationsDeclarees.effectifFormateurs"), None)
+                    elem.clear()
+                    continue
+
+                target_indices = {
+                    idx
+                    for idx in [
+                        idx_region,
+                        idx_actions,
+                        idx_spec1_code,
+                        idx_spec1_label,
+                        idx_spec2_code,
+                        idx_spec2_label,
+                        idx_spec3_code,
+                        idx_spec3_label,
+                        idx_stagiaires,
+                        idx_effectif,
+                    ]
+                    if idx is not None
+                }
+                if not target_indices:
+                    continue
+
+                values: Dict[int, str] = {}
+                for cell in elem.findall(NS + "c"):
+                    ref = cell.attrib.get("r")
+                    if not ref:
+                        continue
+                    col_idx = column_ref_to_index(ref)
+                    if col_idx not in target_indices:
+                        continue
+                    val = get_cell_value(cell, shared_strings)
+                    if val is not None:
+                        values[col_idx] = val
+
+                spec1 = None
+                if idx_spec1_code is not None or idx_spec1_label is not None:
+                    spec1 = (
+                        clean_text(values.get(idx_spec1_code)),
+                        clean_text(values.get(idx_spec1_label)),
+                    )
+                    if not spec1[0] and not spec1[1]:
+                        spec1 = None
+                spec2 = None
+                if idx_spec2_code is not None or idx_spec2_label is not None:
+                    spec2 = (
+                        clean_text(values.get(idx_spec2_code)),
+                        clean_text(values.get(idx_spec2_label)),
+                    )
+                    if not spec2[0] and not spec2[1]:
+                        spec2 = None
+                spec3 = None
+                if idx_spec3_code is not None or idx_spec3_label is not None:
+                    spec3 = (
+                        clean_text(values.get(idx_spec3_code)),
+                        clean_text(values.get(idx_spec3_label)),
+                    )
+                    if not spec3[0] and not spec3[1]:
+                        spec3 = None
+
+                record = Record(
+                    region_code=parse_int(values.get(idx_region)) if idx_region is not None else None,
+                    effectif=parse_int(values.get(idx_effectif)) if idx_effectif is not None else None,
+                    nb_stagiaires=parse_float(values.get(idx_stagiaires)) if idx_stagiaires is not None else None,
+                    actions_cert=parse_float(values.get(idx_actions)) if idx_actions is not None else None,
+                    specialites=(spec1, spec2, spec3),
+                )
+                records.append(record)
+                elem.clear()
+    return records
+
+
+def format_int(value: int) -> str:
+    return f"{value:,}".replace(",", " ")
+
+
+def format_float(value: float, decimals: int = 1) -> str:
+    return f"{value:,.{decimals}f}".replace(",", " ")
+
+
+def percent(part: int, total: int) -> float:
+    if total == 0:
+        return 0.0
+    return part / total * 100
+
+
+def format_percent(value: float, decimals: int = 1) -> str:
+    return f"{value:.{decimals}f}%"
+
+
+MACRO_THEMES = [
+    "Soft Skills",
+    "Tech/Digital",
+    "Commerce/Gestion",
+    "Santé",
+    "Langues",
+    "Juridique",
+    "Industrie",
+    "Services",
+    "Sécurité",
+    "Autre",
+]
+
+
+SPECIFIC_MAPPING: Dict[str, str] = {
+    "enseignement, formation": "Soft Skills",
+    "ressources humaines, gestion du personnel, gestion de l'emploi": "Soft Skills",
+    "développement des capacités comportementales et relationnelles": "Soft Skills",
+    "développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles": "Soft Skills",
+    "formations générales": "Autre",
+    "pluridisciplinaire": "Autre",
+    "finances, banque, assurances": "Commerce/Gestion",
+    "banque et assurances": "Commerce/Gestion",
+    "comptabilité, gestion": "Commerce/Gestion",
+    "techniques de vente": "Commerce/Gestion",
+    "commerce, vente": "Commerce/Gestion",
+    "marketing": "Commerce/Gestion",
+    "soins infirmiers": "Santé",
+    "santé": "Santé",
+    "sanitaire et social": "Santé",
+    "travail social": "Santé",
+    "action sociale": "Santé",
+    "services domestiques": "Services",
+    "services à la personne": "Services",
+    "transport, manutention, magasinage": "Services",
+    "logistique, transport": "Services",
+    "bâtiment et travaux publics": "Industrie",
+    "génie civil, construction, bois": "Industrie",
+    "mécanique générale": "Industrie",
+    "mécanique et structures métalliques": "Industrie",
+    "maintenance industrielle": "Industrie",
+    "électronique": "Tech/Digital",
+    "électricité": "Industrie",
+    "énergie": "Industrie",
+    "informatique": "Tech/Digital",
+    "programmation, développement": "Tech/Digital",
+    "réseaux informatiques": "Tech/Digital",
+    "langues vivantes": "Langues",
+    "linguistique": "Langues",
+    "traduction, interprétation": "Langues",
+    "droit": "Juridique",
+    "sécurité des biens et des personnes": "Sécurité",
+    "sécurité, armée, police": "Sécurité",
+    "hôtellerie, restauration": "Services",
+    "tourisme": "Services",
+    "esthétique, coiffure": "Services",
+    "coiffure": "Services",
+    "esthétique": "Services",
+    "agriculture": "Autre",
+    "agronomie": "Autre",
+    "environnement": "Autre",
+}
+
+
+KEYWORD_RULES: List[Tuple[str, Tuple[str, ...]]] = [
+    ("Tech/Digital", ("informatique", "numér", "programm", "réseau", "logiciel", "digital", "donnée", "cyber", "cloud", "web", "intelligence artificielle", "information")),
+    ("Soft Skills", ("orientation", "ressources humaines", "gestion du personnel", "enseignement", "pédagog", "insertion", "comportement", "formation de formateurs")),
+    ("Commerce/Gestion", ("vente", "commercial", "marketing", "gestion", "finance", "banque", "assurance", "comptabil", "achats", "immobilier")),
+    ("Santé", ("sant", "médic", "paraméd", "infirm", "social", "soin", "pharma", "handicap")),
+    ("Langues", ("langue", "lingu", "tradu", "interpr")),
+    ("Juridique", ("droit", "jurid", "justice", "crimin", "sciences politiques")),
+    ("Industrie", ("mécan", "industri", "électric", "électrotech", "maintenance", "fabrication", "production", "chim", "bâtiment", "travaux publics", "construction", "métall", "plasturg", "energie")),
+    ("Services", ("service", "transport", "logist", "coiff", "esthé", "restauration", "hôtel", "tourisme", "nettoyage", "sport", "animation", "santé animale", "assistan", "secrét")),
+    ("Sécurité", ("sécur", "police", "gendar", "sûreté", "pompier", "secours", "défense")),
+]
+
+
+def normalize_label(label: str) -> str:
+    return label.strip().lower()
+
+
+def classify_specialite(label: Optional[str]) -> str:
+    if not label:
+        return "Autre"
+    norm = normalize_label(label)
+    if norm in SPECIFIC_MAPPING:
+        return SPECIFIC_MAPPING[norm]
+    if "formations générales" in norm or "non class" in norm:
+        return "Autre"
+    for theme, keywords in KEYWORD_RULES:
+        if any(keyword in norm for keyword in keywords):
+            return theme
+    return "Autre"
+
+
+def is_tam(record: Record) -> bool:
+    if record.effectif is None or not (TARGET_MIN <= record.effectif <= TARGET_MAX):
+        return False
+    if record.actions_cert is None:
+        return False
+    if record.nb_stagiaires is None or record.nb_stagiaires <= 0:
+        return False
+    return True
+
+
+def safe_div(num: float, den: int) -> float:
+    return num / den if den else 0.0
+
+
+def compute_top_specialites(records: List[Record]) -> Tuple[List[Dict[str, object]], int, int]:
+    total_base = len(records)
+    tam_records = [r for r in records if is_tam(r)]
+    total_tam = len(tam_records)
+
+    base_counter: Dict[Tuple[str, str], int] = Counter()
+    tam_counter: Dict[Tuple[str, str], int] = Counter()
+
+    for rec in records:
+        if rec.spec1 is None:
+            continue
+        key = rec.spec1
+        base_counter[key] += 1
+    for rec in tam_records:
+        if rec.spec1 is None:
+            continue
+        key = rec.spec1
+        tam_counter[key] += 1
+
+    rows: List[Dict[str, object]] = []
+    for (code, label), count in base_counter.most_common(50):
+        tam_count = tam_counter.get((code, label), 0)
+        rows.append(
+            {
+                "code": code or "-",
+                "label": label or "Non renseigné",
+                "base_count": count,
+                "base_pct": percent(count, total_base),
+                "tam_count": tam_count,
+                "tam_pct": percent(tam_count, total_tam),
+            }
+        )
+
+    return rows, total_base, total_tam
+
+
+def compute_macro_themes(records: List[Record], total_base: int, total_tam: int) -> Tuple[List[Dict[str, object]], Dict[str, Dict[str, object]]]:
+    base_counts: Dict[str, int] = Counter()
+    tam_counts: Dict[str, int] = Counter()
+    tam_stag_sum: Dict[str, float] = defaultdict(float)
+    tam_prod_sum: Dict[str, float] = defaultdict(float)
+
+    tam_records = [r for r in records if is_tam(r)]
+
+    for rec in records:
+        if rec.spec1 is None:
+            continue
+        theme = classify_specialite(rec.spec1[1])
+        base_counts[theme] += 1
+
+    for rec in tam_records:
+        if rec.spec1 is None:
+            continue
+        theme = classify_specialite(rec.spec1[1])
+        tam_counts[theme] += 1
+        if rec.nb_stagiaires is not None:
+            tam_stag_sum[theme] += rec.nb_stagiaires
+            if rec.effectif:
+                tam_prod_sum[theme] += rec.nb_stagiaires / rec.effectif
+
+    macro_rows: List[Dict[str, object]] = []
+    theme_stats: Dict[str, Dict[str, object]] = {}
+
+    for theme in MACRO_THEMES:
+        base_count = base_counts.get(theme, 0)
+        tam_count = tam_counts.get(theme, 0)
+        stag_total = tam_stag_sum.get(theme, 0.0)
+        prod_total = tam_prod_sum.get(theme, 0.0)
+        stag_mean = safe_div(stag_total, tam_count)
+        prod_mean = safe_div(prod_total, tam_count)
+        macro_rows.append(
+            {
+                "theme": theme,
+                "base_count": base_count,
+                "base_pct": percent(base_count, total_base),
+                "tam_count": tam_count,
+                "tam_pct": percent(tam_count, total_tam),
+                "stag_mean": stag_mean,
+            }
+        )
+        theme_stats[theme] = {
+            "tam_count": tam_count,
+            "tam_pct": percent(tam_count, total_tam),
+            "stag_mean": stag_mean,
+            "prod_mean": prod_mean,
+        }
+
+    macro_rows.sort(key=lambda item: item["tam_pct"], reverse=True)
+    return macro_rows, theme_stats
+
+
+def compute_top_specialites_by_theme(records: List[Record]) -> Dict[str, List[str]]:
+    tam_records = [r for r in records if is_tam(r) and r.spec1 is not None]
+    theme_counter: Dict[str, Counter] = defaultdict(Counter)
+    for rec in tam_records:
+        code, label = rec.spec1
+        theme = classify_specialite(label)
+        theme_counter[theme][label or "Non renseigné"] += 1
+
+    top_map: Dict[str, List[str]] = {}
+    for theme, counter in theme_counter.items():
+        names = [label for label, _ in counter.most_common(3)]
+        top_map[theme] = names
+    return top_map
+
+
+def compute_specialites_secondary(records: List[Record]) -> Tuple[List[Dict[str, object]], List[Dict[str, object]], int, int]:
+    spec2_records = [r for r in records if r.spec2 is not None]
+    spec3_records = [r for r in records if r.spec3 is not None]
+
+    total_spec2 = len(spec2_records)
+    total_spec3 = len(spec3_records)
+
+    counter2: Counter = Counter()
+    counter3: Counter = Counter()
+
+    for rec in spec2_records:
+        code, label = rec.spec2
+        counter2[label or "Non renseigné"] += 1
+
+    for rec in spec3_records:
+        code, label = rec.spec3
+        counter3[label or "Non renseigné"] += 1
+
+    top20_spec2 = [
+        {
+            "label": label,
+            "count": count,
+            "pct": percent(count, total_spec2),
+        }
+        for label, count in counter2.most_common(20)
+    ]
+    top20_spec3 = [
+        {
+            "label": label,
+            "count": count,
+            "pct": percent(count, total_spec3),
+        }
+        for label, count in counter3.most_common(20)
+    ]
+
+    return top20_spec2, top20_spec3, total_spec2, total_spec3
+
+
+def compute_macro_theme_priorities(records: List[Record], theme_stats: Dict[str, Dict[str, object]]) -> List[Dict[str, object]]:
+    tam_records = [r for r in records if is_tam(r) and r.spec1 is not None]
+    total_tam = len(tam_records)
+    if total_tam == 0:
+        return []
+    overall_stag_mean = sum(r.nb_stagiaires or 0.0 for r in tam_records) / total_tam
+    overall_prod_mean = sum((r.nb_stagiaires or 0.0) / (r.effectif or 1) for r in tam_records) / total_tam
+
+    rows: List[Dict[str, object]] = []
+    for theme in MACRO_THEMES:
+        stats = theme_stats.get(theme, {})
+        tam_count = int(stats.get("tam_count", 0))
+        tam_pct = float(stats.get("tam_pct", 0.0))
+        stag_mean = float(stats.get("stag_mean", 0.0))
+        prod_mean = float(stats.get("prod_mean", 0.0))
+        if tam_count == 0:
+            priority = "BASSE"
+        elif tam_pct > 15 and (stag_mean > overall_stag_mean or prod_mean > overall_prod_mean):
+            priority = "HAUTE"
+        elif 10 <= tam_pct <= 15:
+            priority = "MOYENNE"
+        elif tam_pct > 15:
+            priority = "MOYENNE"
+        else:
+            priority = "BASSE"
+        rows.append(
+            {
+                "theme": theme,
+                "tam_count": tam_count,
+                "tam_pct": tam_pct,
+                "stag_mean": stag_mean,
+                "prod_mean": prod_mean,
+                "priority": priority,
+            }
+        )
+    rows.sort(key=lambda item: item["tam_pct"], reverse=True)
+    return rows
+
+
+def compute_niches(records: List[Record], total_base: int, total_tam: int) -> List[Dict[str, object]]:
+    base_counter: Counter = Counter()
+    tam_counter: Counter = Counter()
+    tam_records = [r for r in records if is_tam(r)]
+
+    for rec in records:
+        if rec.spec1 is None:
+            continue
+        base_counter[rec.spec1[1] or "Non renseigné"] += 1
+    for rec in tam_records:
+        if rec.spec1 is None:
+            continue
+        tam_counter[rec.spec1[1] or "Non renseigné"] += 1
+
+    niches: List[Dict[str, object]] = []
+    for label, base_count in base_counter.items():
+        base_pct = percent(base_count, total_base)
+        if base_pct >= 2:
+            continue
+        tam_count = tam_counter.get(label, 0)
+        tam_pct = percent(tam_count, total_tam)
+        if tam_pct <= 3:
+            continue
+        ratio = (tam_pct / base_pct) if base_pct > 0 else 0
+        if ratio <= 1.5:
+            continue
+        niches.append(
+            {
+                "label": label,
+                "base_count": base_count,
+                "base_pct": base_pct,
+                "tam_count": tam_count,
+                "tam_pct": tam_pct,
+                "ratio": ratio,
+            }
+        )
+
+    niches.sort(key=lambda item: item["ratio"], reverse=True)
+    return niches
+
+
+def compute_regional_diversity(records: List[Record]) -> List[Dict[str, object]]:
+    region_groups: Dict[int, List[Record]] = defaultdict(list)
+    for rec in records:
+        if rec.region_code is None or rec.spec1 is None:
+            continue
+        region_groups[rec.region_code].append(rec)
+
+    rows: List[Dict[str, object]] = []
+    for region_code, recs in region_groups.items():
+        total = len(recs)
+        counter: Counter = Counter()
+        for rec in recs:
+            label = rec.spec1[1] or "Non renseigné"
+            counter[label] += 1
+        dominant_label, dominant_count = counter.most_common(1)[0]
+        dominant_pct = percent(dominant_count, total)
+        if dominant_pct > 40:
+            diversity = "Faible"
+        elif dominant_pct >= 25:
+            diversity = "Moyenne"
+        else:
+            diversity = "Forte"
+        rows.append(
+            {
+                "region_code": region_code,
+                "region_name": REGION_NAMES.get(region_code, "Autres DOM-TOM"),
+                "distinct": len(counter),
+                "dominant": dominant_label,
+                "dominant_pct": dominant_pct,
+                "diversity": diversity,
+            }
+        )
+
+    rows.sort(key=lambda item: item["region_name"])
+    return rows
+
+
+def write_markdown(
+    top50: List[Dict[str, object]],
+    macro_rows: List[Dict[str, object]],
+    macro_tops: Dict[str, List[str]],
+    spec2_rows: List[Dict[str, object]],
+    spec3_rows: List[Dict[str, object]],
+    total_spec2: int,
+    total_spec3: int,
+    tam_macro_rows: List[Dict[str, object]],
+    niches: List[Dict[str, object]],
+    regional_rows: List[Dict[str, object]],
+    totals: Dict[str, float],
+) -> None:
+    lines: List[str] = []
+    lines.append("# Analyse des spécialités OF France 2025")
+    lines.append("")
+
+    lines.append("## Tableau 1 : Top 50 des spécialités principales (Spé 1)")
+    lines.append("| Rang | Code NSF | Libellé spécialité | OF total | % base | OF TAM | % TAM |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for rank, row in enumerate(top50, start=1):
+        lines.append(
+            "| {rank} | {code} | {label} | {base_count} | {base_pct:.1f}% | {tam_count} | {tam_pct:.1f}% |".format(
+                rank=rank,
+                code=row["code"],
+                label=row["label"],
+                base_count=format_int(row["base_count"]),
+                base_pct=row["base_pct"],
+                tam_count=format_int(row["tam_count"]),
+                tam_pct=row["tam_pct"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 2 : Répartition par macro-thème")
+    lines.append("| Macro-thème | OF total | % base | OF TAM | % TAM | Stag. moyen (TAM) | Spés principales |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for row in macro_rows:
+        top_specs = ", ".join(macro_tops.get(row["theme"], [])) or "-"
+        lines.append(
+            "| {theme} | {base_count} | {base_pct:.1f}% | {tam_count} | {tam_pct:.1f}% | {stag_mean} | {tops} |".format(
+                theme=row["theme"],
+                base_count=format_int(row["base_count"]),
+                base_pct=row["base_pct"],
+                tam_count=format_int(row["tam_count"]),
+                tam_pct=row["tam_pct"],
+                stag_mean=format_float(row["stag_mean"], 1) if row["tam_count"] else "-",
+                tops=top_specs,
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 3a : Top 20 spécialités secondaires (Spé 2)")
+    lines.append(
+        "| Rang | Libellé spécialité | OF avec Spé2 | % des {total} |".format(
+            total=format_int(total_spec2)
+        )
+    )
+    lines.append("| --- | --- | --- | --- |")
+    for rank, row in enumerate(spec2_rows, start=1):
+        lines.append(
+            "| {rank} | {label} | {count} | {pct:.1f}% |".format(
+                rank=rank,
+                label=row["label"],
+                count=format_int(row["count"]),
+                pct=row["pct"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 3b : Top 20 spécialités tertiaires (Spé 3)")
+    lines.append(
+        "| Rang | Libellé spécialité | OF avec Spé3 | % des {total} |".format(
+            total=format_int(total_spec3)
+        )
+    )
+    lines.append("| --- | --- | --- | --- |")
+    for rank, row in enumerate(spec3_rows, start=1):
+        lines.append(
+            "| {rank} | {label} | {count} | {pct:.1f}% |".format(
+                rank=rank,
+                label=row["label"],
+                count=format_int(row["count"]),
+                pct=row["pct"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 4 : TAM qualifié par macro-thème")
+    lines.append("| Macro-thème | OF TAM | % TAM | Stag. moyen | Prod est. | Priorité |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for row in tam_macro_rows:
+        lines.append(
+            "| {theme} | {tam_count} | {tam_pct:.1f}% | {stag_mean} | {prod_mean} | {priority} |".format(
+                theme=row["theme"],
+                tam_count=format_int(row["tam_count"]),
+                tam_pct=row["tam_pct"],
+                stag_mean=format_float(row["stag_mean"], 1) if row["tam_count"] else "-",
+                prod_mean=format_float(row["prod_mean"], 2) if row["tam_count"] else "-",
+                priority=row["priority"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 5 : Niches sur-représentées dans le TAM")
+    lines.append("| Spécialité | OF base | % base | OF TAM | % TAM | Ratio TAM/base |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    if niches:
+        for row in niches:
+            lines.append(
+                "| {label} | {base_count} | {base_pct:.2f}% | {tam_count} | {tam_pct:.2f}% | {ratio:.2f} |".format(
+                    label=row["label"],
+                    base_count=format_int(row["base_count"]),
+                    base_pct=row["base_pct"],
+                    tam_count=format_int(row["tam_count"]),
+                    tam_pct=row["tam_pct"],
+                    ratio=row["ratio"],
+                )
+            )
+    else:
+        lines.append("| Aucune spécialité | - | - | - | - | - |")
+    lines.append("")
+
+    lines.append("## Tableau 6 : Diversité des spécialités par région")
+    lines.append("| Région | Nb spés différentes | Spé dominante | % spé dominante | Diversité |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in regional_rows:
+        lines.append(
+            "| {region} | {distinct} | {dominant} | {pct:.1f}% | {diversity} |".format(
+                region=row["region_name"],
+                distinct=format_int(row["distinct"]),
+                dominant=row["dominant"],
+                pct=row["dominant_pct"],
+                diversity=row["diversity"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Synthèse")
+    lines.append(
+        "Spé 1 : {spec1_count:,} OF renseignés ({spec1_pct:.1f}%).".format(
+            spec1_count=int(totals["spec1_count"]),
+            spec1_pct=totals["spec1_pct"],
+        ).replace(",", " ")
+    )
+    lines.append(
+        "Spé 2 : {spec2_count:,} OF ({spec2_pct:.1f}%).".format(
+            spec2_count=int(totals["spec2_count"]),
+            spec2_pct=totals["spec2_pct"],
+        ).replace(",", " ")
+    )
+    lines.append(
+        "Spé 3 : {spec3_count:,} OF ({spec3_pct:.1f}%).".format(
+            spec3_count=int(totals["spec3_count"]),
+            spec3_pct=totals["spec3_pct"],
+        ).replace(",", " ")
+    )
+    lines.append("")
+
+    lines.append(
+        "Top 5 spécialités : {top_list}.".format(
+            top_list=", ".join(
+                [
+                    "{label} : {count} OF ({base_pct:.1f}% base, {tam_pct:.1f}% TAM)".format(
+                        label=row["label"],
+                        count=format_int(row["base_count"]),
+                        base_pct=row["base_pct"],
+                        tam_pct=row["tam_pct"],
+                    )
+                    for row in top50[:5]
+                ]
+            )
+        )
+    )
+    top_macro_summary = ", ".join(
+        "{idx}. {theme} : {tam_pct:.1f}% TAM".format(idx=rank, theme=row["theme"], tam_pct=row["tam_pct"])
+        for rank, row in enumerate(tam_macro_rows[:3], start=1)
+    )
+    if top_macro_summary:
+        lines.append(f"Macro-thèmes prioritaires : {top_macro_summary}.")
+    else:
+        lines.append("Macro-thèmes prioritaires : aucun.")
+    if niches:
+        lines.append(
+            "Niches émergentes : "
+            + ", ".join(
+                "{label} : Sur-représentation ×{ratio:.1f}".format(label=row["label"], ratio=row["ratio"])
+                for row in niches
+            )
+            + "."
+        )
+    else:
+        lines.append("Niches émergentes : aucune spécialité sur-représentée.")
+    lines.append("")
+
+    with open(OUTPUT_MARKDOWN, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def write_csv(top50: List[Dict[str, object]], macro_rows: List[Dict[str, object]], niches: List[Dict[str, object]]) -> None:
+    with open(OUTPUT_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["table", "rang", "code", "label", "of_total", "pct_base", "of_tam", "pct_tam", "extra"])
+        for rank, row in enumerate(top50, start=1):
+            writer.writerow(
+                [
+                    "top50",
+                    rank,
+                    row["code"],
+                    row["label"],
+                    row["base_count"],
+                    round(row["base_pct"], 2),
+                    row["tam_count"],
+                    round(row["tam_pct"], 2),
+                    "",
+                ]
+            )
+        for row in macro_rows:
+            writer.writerow(
+                [
+                    "macro_theme",
+                    "",
+                    "",
+                    row["theme"],
+                    row["base_count"],
+                    round(row["base_pct"], 2),
+                    row["tam_count"],
+                    round(row["tam_pct"], 2),
+                    round(row["stag_mean"], 2) if row["tam_count"] else "",
+                ]
+            )
+        for row in niches:
+            writer.writerow(
+                [
+                    "niche",
+                    "",
+                    "",
+                    row["label"],
+                    row["base_count"],
+                    round(row["base_pct"], 2),
+                    row["tam_count"],
+                    round(row["tam_pct"], 2),
+                    round(row["ratio"], 2),
+                ]
+            )
+
+
+def main() -> None:
+    ensure_output_dir()
+    records = load_records()
+
+    top50, total_base, total_tam = compute_top_specialites(records)
+    macro_rows, theme_stats = compute_macro_themes(records, total_base, total_tam)
+    macro_tops = compute_top_specialites_by_theme(records)
+    spec2_rows, spec3_rows, total_spec2, total_spec3 = compute_specialites_secondary(records)
+    tam_macro_rows = compute_macro_theme_priorities(records, theme_stats)
+    niches = compute_niches(records, total_base, total_tam)
+    regional_rows = compute_regional_diversity(records)
+
+    spec1_count = sum(1 for r in records if r.spec1 is not None)
+    totals = {
+        "spec1_count": spec1_count,
+        "spec2_count": total_spec2,
+        "spec3_count": total_spec3,
+        "spec1_pct": percent(spec1_count, total_base),
+        "spec2_pct": percent(total_spec2, total_base),
+        "spec3_pct": percent(total_spec3, total_base),
+        "total_base": total_base,
+        "total_tam": total_tam,
+    }
+
+    write_markdown(
+        top50,
+        macro_rows,
+        macro_tops,
+        spec2_rows,
+        spec3_rows,
+        total_spec2,
+        total_spec3,
+        tam_macro_rows,
+        niches,
+        regional_rows,
+        totals,
+    )
+    write_csv(top50, macro_rows, niches)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an analysis script that parses the OF 3-10 workbook to compute specialty rankings, macro-thèmes, TAM metrics, and regional diversity
- export the requested markdown and CSV tables covering top 50 spécialités, macro-thèmes, TAM focus, and niches

## Testing
- python analyze_specialites.py

------
https://chatgpt.com/codex/tasks/task_e_68ddddc9bd888331a4bc7dae15acc34a