### PR TITLE
Add polyvalence reporting for multi-speciality OF analysis

### DIFF
--- a/analysis_outputs/polyvalence_analysis.md
+++ b/analysis_outputs/polyvalence_analysis.md
@@ -1,0 +1,88 @@
+# Analyse polyvalence OF France 2025
+
+## Tableau 1a : Spécialités déclarées (cumulatives)
+| Nb spécialités | OF total | % base | OF TAM | % TAM | Stag. moyen TAM |
+| --- | --- | --- | --- | --- | --- |
+| 0 (non renseigné) | 9 201 | 6.0% | 0 | 0.0% | - |
+| 1 seule | 144 906 | 94.0% | 12 303 | 100.0% | 266 |
+| 2 spécialités | 29 778 | 19.3% | 3 836 | 31.2% | 264 |
+| 3 spécialités | 12 642 | 8.2% | 1 736 | 14.1% | 279 |
+
+## Tableau 1b : Répartition exclusive des OF
+| Statut | OF | % base |
+| --- | --- | --- |
+| Non renseigné | 9 201 | 6.0% |
+| Spécialisés | 115 128 | 74.7% |
+| Diversifiés | 17 136 | 11.1% |
+| Polyvalents | 12 642 | 8.2% |
+
+## Tableau 2 : Polyvalence vs activité (TAM)
+| Nb spécialités | OF TAM | % TAM | Stag. moyen | Prod. estimée | Effectif moyen |
+| --- | --- | --- | --- | --- | --- |
+| 1 spécialité | 8 467 | 68.8% | 267 | 50.3 | 5.4 |
+| 2 spécialités | 2 100 | 17.1% | 252 | 47.7 | 5.3 |
+| 3 spécialités | 1 736 | 14.1% | 279 | 48.3 | 6.2 |
+
+## Tableau 3 : Paires de spécialités les plus fréquentes
+| Rang | Spé 1 | Spé 2 | OF | % multi-spés | Stag. moyen TAM | Interprétation |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Commerce, vente | Ressources humaines, gestion du personnel, gestion de l'emploi | 1 101 | 3.7% | 260 | Offre combinant Commerce, vente & Ressources humaines, gestion du personnel, gestion de l'emploi |
+| 2 | Commerce, vente | Comptabilité, gestion | 877 | 2.9% | 164 | Offre combinant Commerce, vente & Comptabilité, gestion |
+| 3 | Comptabilité, gestion | Ressources humaines, gestion du personnel, gestion de l'emploi | 837 | 2.8% | 140 | Offre combinant Comptabilité, gestion & Ressources humaines, gestion du personnel, gestion de l'emploi |
+| 4 | Développement des capacités comportementales et relationnelles | Développement des capacités individuelles d'organisation | 800 | 2.7% | 307 | Offre combinant Développement des capacités comportementales et relationnelles & Développement des capacités individuelles d'organisation |
+| 5 | Développement des capacités comportementales et relationnelles | Ressources humaines, gestion du personnel, gestion de l'emploi | 724 | 2.4% | 304 | Offre combinant Développement des capacités comportementales et relationnelles & Ressources humaines, gestion du personnel, gestion de l'emploi |
+| 6 | Développement des capacités comportementales et relationnelles | Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles | 683 | 2.3% | 179 | Offre combinant Développement des capacités comportementales et relationnelles & Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles |
+| 7 | Commerce, vente | Développement des capacités comportementales et relationnelles | 551 | 1.9% | 375 | Offre combinant Commerce, vente & Développement des capacités comportementales et relationnelles |
+| 8 | Commerce, vente | Spécialités plurivalentes des échanges et de la gestion | 466 | 1.6% | 228 | Offre combinant Commerce, vente & Spécialités plurivalentes des échanges et de la gestion |
+| 9 | Autres... | Formations générales | 430 | 1.4% | 262 | Offre combinant Autres... & Formations générales |
+| 10 | Commerce, vente | Formations générales | 430 | 1.4% | 211 | Offre combinant Commerce, vente & Formations générales |
+| 11 | Enseignement, formation | Formations générales | 415 | 1.4% | 333 | Offre combinant Enseignement, formation & Formations générales |
+| 12 | Commerce, vente | Finances, banque, assurances | 406 | 1.4% | 374 | Offre combinant Commerce, vente & Finances, banque, assurances |
+| 13 | Enseignement, formation | Santé | 402 | 1.3% | 396 | Offre combinant Enseignement, formation & Santé |
+| 14 | Développement des capacités comportementales et relationnelles | Enseignement, formation | 375 | 1.3% | 314 | Offre combinant Développement des capacités comportementales et relationnelles & Enseignement, formation |
+| 15 | Commerce, vente | Informatique, traitement de l'information, réseaux de transmission des données | 374 | 1.3% | 160 | Offre combinant Commerce, vente & Informatique, traitement de l'information, réseaux de transmission des données |
+| 16 | Informatique, traitement de l'information, réseaux de transmission des données | Secrétariat, bureautique | 371 | 1.2% | 119 | Offre combinant Informatique, traitement de l'information, réseaux de transmission des données & Secrétariat, bureautique |
+| 17 | Comptabilité, gestion | Finances, banque, assurances | 344 | 1.2% | 443 | Offre combinant Comptabilité, gestion & Finances, banque, assurances |
+| 18 | Commerce, vente | Enseignement, formation | 325 | 1.1% | 325 | Offre combinant Commerce, vente & Enseignement, formation |
+| 19 | Autres... | Enseignement, formation | 319 | 1.1% | 199 | Offre combinant Autres... & Enseignement, formation |
+| 20 | Formations générales | Ressources humaines, gestion du personnel, gestion de l'emploi | 318 | 1.1% | 282 | Offre combinant Formations générales & Ressources humaines, gestion du personnel, gestion de l'emploi |
+
+## Tableau 4 : Polyvalence par région
+| Région | OF 1 spé | OF 2+ spés | % polyvalents | vs national (pp) |
+| --- | --- | --- | --- | --- |
+| Autres territoires | 4 | 3 | 42.9% | +23.5 |
+| Mayotte | 103 | 59 | 36.0% | +16.7 |
+| Martinique | 541 | 248 | 30.0% | +10.6 |
+| Guadeloupe | 781 | 344 | 28.9% | +9.6 |
+| Guyane | 369 | 147 | 26.8% | +7.5 |
+| Corse | 300 | 90 | 22.2% | +2.9 |
+| Grand Est | 6 115 | 1 793 | 21.4% | +2.1 |
+| La Réunion | 1 866 | 560 | 21.3% | +1.9 |
+| Hauts-de-France | 5 921 | 1 610 | 20.2% | +0.9 |
+| Pays de la Loire | 6 131 | 1 629 | 19.8% | +0.4 |
+| Bourgogne-Franche-Comté | 3 292 | 859 | 19.4% | +0.1 |
+| Auvergne-Rhône-Alpes | 15 935 | 4 137 | 19.4% | +0.1 |
+| Provence-Alpes-Côte d'Azur | 10 101 | 2 610 | 19.2% | -0.1 |
+| Île-de-France | 30 475 | 7 656 | 19.1% | -0.3 |
+| Occitanie | 12 035 | 2 977 | 18.4% | -0.9 |
+| Normandie | 3 908 | 936 | 18.2% | -1.1 |
+| Bretagne | 4 221 | 1 020 | 18.2% | -1.2 |
+| Nouvelle-Aquitaine | 9 956 | 2 407 | 18.1% | -1.2 |
+| Centre-Val de Loire | 3 074 | 693 | 17.0% | -2.4 |
+| National | 115 128 | 29 778 | 19.3% | +0.0 |
+
+## Tableau 5 : Polyvalence selon l'effectif (TAM)
+| Effectif | OF 1 spé | OF 2 spés | OF 3 spés | % polyvalents |
+| --- | --- | --- | --- | --- |
+| 3 | 2 104 | 542 | 254 | 27.4% |
+| 4 | 1 708 | 429 | 275 | 29.2% |
+| 5-6 | 2 289 | 524 | 455 | 30.0% |
+| 7-8 | 1 366 | 351 | 393 | 35.3% |
+| 9-10 | 1 000 | 254 | 359 | 38.0% |
+
+## Synthèse
+- Répartition : 74.7% spécialisés (1 spé), 11.1% diversifiés (2 spés) et 8.2% polyvalents (3 spés).
+- TAM : les OF à 3 spés forment en moyenne 279 stagiaires (+12 vs 1 spé).
+- Top combinaisons : Commerce, vente + Ressources humaines, gestion du personnel, gestion de l'emploi (1 101 OF); Commerce, vente + Comptabilité, gestion (877 OF); Comptabilité, gestion + Ressources humaines, gestion du personnel, gestion de l'emploi (837 OF).
+- Régions les plus polyvalentes : Mayotte (36.0%), les moins : Centre-Val de Loire (17.0%).
+- Polyvalence et taille : pic à 9-10 formateurs (38.0% d'OF à 2+ spés).

--- a/analysis_outputs/polyvalence_combinations.csv
+++ b/analysis_outputs/polyvalence_combinations.csv
@@ -1,0 +1,2727 @@
+specialite_1,specialite_2,of,pct_multi,stag_mean_tam
+"Commerce, vente","Ressources humaines, gestion du personnel, gestion de l'emploi",1101,3.6973604674591978,259.8269230769231
+"Commerce, vente","Comptabilité, gestion",877,2.9451272751695883,164.35922330097088
+"Comptabilité, gestion","Ressources humaines, gestion du personnel, gestion de l'emploi",837,2.8107999194035864,140.23125
+Développement des capacités comportementales et relationnelles,Développement des capacités individuelles d'organisation,800,2.686547115320035,306.7837837837838
+Développement des capacités comportementales et relationnelles,"Ressources humaines, gestion du personnel, gestion de l'emploi",724,2.4313251393646316,303.9056603773585
+Développement des capacités comportementales et relationnelles,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",683,2.29363959970448,179.2429906542056
+"Commerce, vente",Développement des capacités comportementales et relationnelles,551,1.8503593256766742,375.2111111111111
+"Commerce, vente",Spécialités plurivalentes des échanges et de la gestion,466,1.5649136946739202,228.27083333333334
+Autres...,Formations générales,430,1.4440190744845187,261.84313725490193
+"Commerce, vente",Formations générales,430,1.4440190744845187,211.4516129032258
+"Enseignement, formation",Formations générales,415,1.393646316072268,333.2391304347826
+"Commerce, vente","Finances, banque, assurances",406,1.3634226610249176,374.22727272727275
+"Enseignement, formation",Santé,402,1.3499899254483174,396.4074074074074
+Développement des capacités comportementales et relationnelles,"Enseignement, formation",375,1.2593189603062664,314.44444444444446
+"Commerce, vente","Informatique, traitement de l'information, réseaux de transmission des données",374,1.2559607764121163,160.43243243243242
+"Informatique, traitement de l'information, réseaux de transmission des données","Secrétariat, bureautique",371,1.2458862247296663,119.075
+"Comptabilité, gestion","Finances, banque, assurances",344,1.155215259587615,443.15384615384613
+"Commerce, vente","Enseignement, formation",325,1.0914097655987642,325.1363636363636
+Autres...,"Enseignement, formation",319,1.0712606622338638,198.7037037037037
+Formations générales,"Ressources humaines, gestion du personnel, gestion de l'emploi",318,1.067902478339714,281.6792452830189
+"Enseignement, formation","Ressources humaines, gestion du personnel, gestion de l'emploi",313,1.0511115588689637,292.0217391304348
+Autres...,"Commerce, vente",298,1.000738800456713,244.75
+"Comptabilité, gestion","Secrétariat, bureautique",295,0.990664248774263,110.13636363636364
+"Comptabilité, gestion","Informatique, traitement de l'information, réseaux de transmission des données",290,0.9738733293035127,203.3272727272727
+Santé,Travail social,286,0.9604405937269125,303.3181818181818
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Secrétariat, bureautique",280,0.9402914903620121,155.55769230769232
+Développement des capacités comportementales et relationnelles,Formations générales,275,0.923500570891262,241.52727272727273
+"Commerce, vente",Spécialités plurivalentes de la communication,274,0.9201423869971119,131.55
+Développement des capacités comportementales et relationnelles,Développement des capacités mentales et apprentissages de base,271,0.9100678353146618,240.91666666666666
+"Agro-alimentaire, alimentation, cuisine","Commerce, vente",270,0.9067096514205117,288.89473684210526
+Formations générales,"Langues vivantes, civilisations étrangères et régionales",266,0.8932769158439116,164.6451612903226
+Formations générales,"Sécurité des biens et des personnes, police, surveillance",265,0.8899187319497616,541.8305084745763
+Autres...,"Informatique, traitement de l'information, réseaux de transmission des données",264,0.8865605480556116,96.26923076923077
+Autres...,Développement des capacités comportementales et relationnelles,260,0.8731278124790114,275.4375
+"Commerce, vente","Secrétariat, bureautique",254,0.8529787091141111,133.58333333333334
+"Informatique, traitement de l'information, réseaux de transmission des données","Ressources humaines, gestion du personnel, gestion de l'emploi",253,0.849620525219961,226.17857142857142
+Formations générales,"Transport, manutention, magasinage",251,0.842904157431661,434.4347826086956
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Ressources humaines, gestion du personnel, gestion de l'emploi",251,0.842904157431661,158.38636363636363
+Formations générales,Santé,245,0.8227550540667606,376.6744186046512
+Formations générales,"Informatique, traitement de l'information, réseaux de transmission des données",242,0.8126805023843106,182.41176470588235
+"Electricité, électronique (non compris automatisme et productique)","Transport, manutention, magasinage",241,0.8093223184901605,923.8666666666667
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes de la communication,234,0.7858150312311102,221.3793103448276
+"Sécurité des biens et des personnes, police, surveillance","Transport, manutention, magasinage",227,0.7623077439720599,882.2619047619048
+"Commerce, vente",Journalisme et communication,216,0.7253677211364095,139.71428571428572
+Santé,"Sécurité des biens et des personnes, police, surveillance",210,0.7052186177715092,377.26666666666665
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes des échanges et de la gestion,206,0.691785882194909,151.65625
+"Français, littérature et civilisation françaises","Langues vivantes, civilisations étrangères et régionales",203,0.6817113305124588,167.0909090909091
+Santé,Spécialités plurivalentes sanitaires et sociales,202,0.6783531466183088,200.28571428571428
+"Droit, sciences politiques","Ressources humaines, gestion du personnel, gestion de l'emploi",201,0.6749949627241587,300.625
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes de la communication,199,0.6682785949358586,151.56410256410257
+Spécialités plurivalentes de la communication,Spécialités plurivalentes des échanges et de la gestion,198,0.6649204110417086,180.44827586206895
+"Enseignement, formation",Travail social,198,0.6649204110417086,202.72727272727272
+"Enseignement, formation","Sécurité des biens et des personnes, police, surveillance",195,0.6548458593592585,713.3939393939394
+Développement des capacités comportementales et relationnelles,Santé,195,0.6548458593592585,168.0
+"Commerce, vente","Langues vivantes, civilisations étrangères et régionales",192,0.6447713076768083,275.4594594594595
+"Commerce, vente","Transport, manutention, magasinage",191,0.6414131237826584,344.8
+Développement des capacités individuelles d'organisation,"Ressources humaines, gestion du personnel, gestion de l'emploi",189,0.6346967559943583,305.2083333333333
+"Comptabilité, gestion",Spécialités plurivalentes des échanges et de la gestion,188,0.6313385721002083,226.30434782608697
+"Comptabilité, gestion",Formations générales,187,0.6279803882060582,130.09677419354838
+"Enseignement, formation","Informatique, traitement de l'information, réseaux de transmission des données",187,0.6279803882060582,118.11111111111111
+"Enseignement, formation","Transport, manutention, magasinage",181,0.6078312848411579,526.55
+Formations générales,Linguistique,177,0.5943985492645578,292.3157894736842
+Autres...,"Ressources humaines, gestion du personnel, gestion de l'emploi",172,0.5776076297938075,139.16
+Autres...,"Sécurité des biens et des personnes, police, surveillance",171,0.5742494458996575,531.84375
+Spécialités plurivalentes sanitaires et sociales,Travail social,170,0.5708912620055074,326.3529411764706
+"Productions animales, élevage spécialisé, aquaculture, ...","Productions végétales,cultures spécialisées",167,0.5608167103230574,171.42857142857142
+"Productions végétales,cultures spécialisées",Spécialités plurivalentes de l'agronomie et de l'agriculture,166,0.5574585264289073,224.4
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Formations générales,165,0.5541003425347573,199.51724137931035
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités plurivalentes de l'agronomie et de l'agriculture,164,0.5507421586406072,296.4
+Autres...,Santé,163,0.5473839747464572,244.6315789473684
+Psychologie,Santé,162,0.5440257908523071,213.625
+"Enseignement, formation","Langues vivantes, civilisations étrangères et régionales",161,0.5406676069581571,131.25
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Santé,161,0.5406676069581571,301.0740740740741
+"Coiffure, esthétique et autres spécialités des services aux personnes",Formations générales,160,0.537309423064007,325.32
+"Agro-alimentaire, alimentation, cuisine",Formations générales,158,0.5305930552757069,167.67857142857142
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Développement des capacités individuelles d'organisation,157,0.5272348713815569,161.25
+Bâtiment: construction et couverture,Bâtiment: finitions,155,0.5205185035932568,274.94117647058823
+"Droit, sciences politiques",Economie,153,0.5138021358049567,135.0
+Développement des capacités comportementales et relationnelles,"Vie familiale, vie sociale et autres formations au développement personnel",153,0.5138021358049567,100.25
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Enseignement, formation",153,0.5138021358049567,164.58333333333334
+"Comptabilité, gestion","Droit, sciences politiques",150,0.5037275841225065,197.77777777777777
+Formations générales,Spécialités plurivalentes des échanges et de la gestion,147,0.4936530324400564,157.375
+"Commerce, vente",Spécialités plurivalentes des services,146,0.4902948485459063,168.6
+Journalisme et communication,Spécialités plurivalentes de la communication,144,0.48357848075760623,160.75
+"Electricité, électronique (non compris automatisme et productique)","Sécurité des biens et des personnes, police, surveillance",142,0.47686211296930614,740.9736842105264
+Formations générales,"Secrétariat, bureautique",141,0.47350392907515615,148.3548387096774
+"Informatique, traitement de l'information, réseaux de transmission des données",Journalisme et communication,140,0.47014574518100605,354.53846153846155
+"Commerce, vente","Droit, sciences politiques",138,0.463429377392706,222.86666666666667
+Développement des capacités comportementales et relationnelles,"Informatique, traitement de l'information, réseaux de transmission des données",136,0.4567130096044059,203.2
+"Langues vivantes, civilisations étrangères et régionales","Secrétariat, bureautique",133,0.4466384579219558,119.5
+"Commerce, vente",Linguistique,131,0.43992209013365574,203.9090909090909
+"Droit, sciences politiques",Formations générales,130,0.4365639062395057,296.1
+"Langues vivantes, civilisations étrangères et régionales",Linguistique,130,0.4365639062395057,43.25
+Autres...,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",128,0.4298475384512056,534.6666666666666
+"Enseignement, formation",Spécialités plurivalentes sanitaires et sociales,128,0.4298475384512056,308.14285714285717
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Sécurité des biens et des personnes, police, surveillance",128,0.4298475384512056,330.34615384615387
+"Commerce, vente",Développement des capacités individuelles d'organisation,126,0.4231311706629055,212.21428571428572
+Formations générales,Spécialités plurivalentes des services,125,0.41977298676875546,98.71428571428571
+"Commerce, vente",Economie,121,0.4063402511921553,0.0
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes de la communication,120,0.4029820672980053,136.94117647058823
+Développement des capacités comportementales et relationnelles,Spécialités concernant plusieurs capacités,119,0.3996238834038552,332.375
+"Accueil, hôtellerie, tourisme","Commerce, vente",119,0.3996238834038552,335.61538461538464
+Développement des capacités comportementales et relationnelles,Psychologie,118,0.3962656995097052,202.16666666666666
+"Informatique, traitement de l'information, réseaux de transmission des données","Langues vivantes, civilisations étrangères et régionales",116,0.38954933172140505,160.6315789473684
+Autres...,"Transport, manutention, magasinage",114,0.38283296393310495,392.18518518518516
+"Electricité, électronique (non compris automatisme et productique)",Formations générales,114,0.38283296393310495,500.0625
+Développement des capacités comportementales et relationnelles,Travail social,113,0.3794747800389549,149.25
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Transport, manutention, magasinage",113,0.3794747800389549,622.55
+Autres...,"Comptabilité, gestion",111,0.37275841225065487,115.88888888888889
+"Finances, banque, assurances","Ressources humaines, gestion du personnel, gestion de l'emploi",111,0.37275841225065487,350.6666666666667
+"Secrétariat, bureautique",Spécialités plurivalentes de la communication,109,0.3660420444623548,160.75
+Spécialités plurivalentes des services,Spécialités plurivalentes des échanges et de la gestion,108,0.36268386056820473,119.6
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Travail social,107,0.3593256766740547,299.6666666666667
+"Droit, sciences politiques","Finances, banque, assurances",105,0.3526093088857546,333.0
+"Finances, banque, assurances",Spécialités plurivalentes des échanges et de la gestion,101,0.3391765733091544,127.0
+"Commerce, vente",Santé,101,0.3391765733091544,242.1764705882353
+Développement des capacités comportementales et relationnelles,"Sécurité des biens et des personnes, police, surveillance",101,0.3391765733091544,542.375
+Linguistique,"Secrétariat, bureautique",101,0.3391765733091544,759.7368421052631
+Autres...,"Langues vivantes, civilisations étrangères et régionales",99,0.3324602055208543,145.93333333333334
+Développement des capacités individuelles d'organisation,Développement des capacités mentales et apprentissages de base,99,0.3324602055208543,371.3333333333333
+Formations générales,Spécialités plurivalentes de la communication,99,0.3324602055208543,88.7
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes des échanges et de la gestion,98,0.32910202162670427,204.5
+Journalisme et communication,"Techniques de l'image et du son, métiers connexes du spectacle",97,0.3257438377325542,44.666666666666664
+"Enseignement, formation","Secrétariat, bureautique",95,0.3190274699442541,126.54545454545455
+"Informatique, traitement de l'information, réseaux de transmission des données","Mathématiques, statistiques",94,0.31566928605010414,213.0
+Formations générales,Spécialités plurivalentes sanitaires et sociales,94,0.31566928605010414,154.125
+Psychologie,Travail social,93,0.3123111021559541,306.6666666666667
+"Agro-alimentaire, alimentation, cuisine","Ressources humaines, gestion du personnel, gestion de l'emploi",92,0.30895291826180404,467.53846153846155
+"Langues vivantes, civilisations étrangères et régionales","Ressources humaines, gestion du personnel, gestion de l'emploi",92,0.30895291826180404,154.76470588235293
+Formations générales,"Français, littérature et civilisation françaises",91,0.305594734367654,354.625
+"Agro-alimentaire, alimentation, cuisine","Langues vivantes, civilisations étrangères et régionales",91,0.305594734367654,274.76
+Spécialités plurivalentes des échanges et de la gestion,"Transport, manutention, magasinage",89,0.2988783665793539,82.83333333333333
+Autres...,"Secrétariat, bureautique",89,0.2988783665793539,88.0
+"Animation culturelle, sportive et de loisirs",Pratiques sportives,89,0.2988783665793539,108.0
+"Comptabilité, gestion","Langues vivantes, civilisations étrangères et régionales",88,0.29552018268520386,184.71428571428572
+"Coiffure, esthétique et autres spécialités des services aux personnes","Enseignement, formation",87,0.2921619987910538,173.25
+"Informatique, traitement de l'information, réseaux de transmission des données",Linguistique,86,0.28880381489690377,152.52631578947367
+"Comptabilité, gestion",Economie,85,0.2854456310027537,252.0
+"Enseignement, formation",Pratiques sportives,85,0.2854456310027537,153.0
+Journalisme et communication,"Ressources humaines, gestion du personnel, gestion de l'emploi",85,0.2854456310027537,98.75
+"Commerce, vente","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",85,0.2854456310027537,127.64285714285714
+Formations générales,Technologies industrielles fondamentales,85,0.2854456310027537,221.0
+"Accueil, hôtellerie, tourisme","Agro-alimentaire, alimentation, cuisine",83,0.2787292632144536,265.4166666666667
+"Electricité, électronique (non compris automatisme et productique)","Energie, génie climatique",83,0.2787292632144536,738.875
+Formations générales,"Spécialités pluridisciplinaires, sciences humaines et droit",82,0.2753710793203036,243.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes sanitaires et sociales,82,0.2753710793203036,442.3888888888889
+Autres...,"Coiffure, esthétique et autres spécialités des services aux personnes",80,0.2686547115320035,211.14285714285714
+"Informatique, traitement de l'information, réseaux de transmission des données","Sécurité des biens et des personnes, police, surveillance",80,0.2686547115320035,407.94117647058823
+"Comptabilité, gestion",Spécialités plurivalentes de la communication,80,0.2686547115320035,190.17391304347825
+Formations générales,Travail social,78,0.2619383437437034,157.91666666666666
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes des services,77,0.25858015984955335,263.55555555555554
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Développement des capacités mentales et apprentissages de base,77,0.25858015984955335,220.07142857142858
+Bâtiment: construction et couverture,Formations générales,77,0.25858015984955335,384.6666666666667
+"Aménagement paysager (parcs, jardins, espaces verts)","Productions végétales,cultures spécialisées",77,0.25858015984955335,493.0
+"Comptabilité, gestion",Développement des capacités comportementales et relationnelles,76,0.2552219759554033,250.64705882352942
+"Informatique, traitement de l'information, réseaux de transmission des données",Santé,75,0.25186379206125326,266.1818181818182
+Bâtiment: construction et couverture,"Energie, génie climatique",75,0.25186379206125326,387.3333333333333
+"Animation culturelle, sportive et de loisirs","Enseignement, formation",75,0.25186379206125326,584.75
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Musique, arts du spectacle",74,0.2485056081671032,169.25
+Autres...,Spécialités plurivalentes de la communication,74,0.2485056081671032,144.41666666666666
+Santé,"Transport, manutention, magasinage",74,0.2485056081671032,526.9333333333333
+"Agro-alimentaire, alimentation, cuisine","Sécurité des biens et des personnes, police, surveillance",74,0.2485056081671032,291.2631578947368
+Spécialités plurivalentes de la communication,Spécialités plurivalentes des services,74,0.2485056081671032,123.16666666666667
+"Nettoyage, assainissement, protection de l'environnement","Sécurité des biens et des personnes, police, surveillance",73,0.24514742427295316,480.76190476190476
+Santé,"Secrétariat, bureautique",73,0.24514742427295316,870.8125
+"Droit, sciences politiques","Spécialités pluridisciplinaires, sciences humaines et droit",73,0.24514742427295316,90.4
+"Agro-alimentaire, alimentation, cuisine",Autres...,73,0.24514742427295316,360.3125
+Bâtiment: construction et couverture,"Transport, manutention, magasinage",72,0.24178924037880312,1130.6875
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités plurivalentes de l'agronomie et de l'agriculture,72,0.24178924037880312,371.5
+"Informatique, traitement de l'information, réseaux de transmission des données","Techniques de l'image et du son, métiers connexes du spectacle",71,0.23843105648465307,40.5
+Développement des capacités mentales et apprentissages de base,"Enseignement, formation",71,0.23843105648465307,201.0
+"Enseignement, formation",Psychologie,70,0.23507287259050302,325.8333333333333
+Arts plastiques,Autres disciplines artistiques et spécialités artistiques plurivalentes,70,0.23507287259050302,106.0
+Formations générales,Psychologie,70,0.23507287259050302,267.25
+Développement des capacités individuelles d'organisation,"Enseignement, formation",69,0.231714688696353,120.2
+"Comptabilité, gestion","Transport, manutention, magasinage",69,0.231714688696353,151.88888888888889
+Spécialités plurivalentes de la communication,"Techniques de l'image et du son, métiers connexes du spectacle",68,0.22835650480220296,51.2
+"Commerce, vente",Spécialités plurivalentes sanitaires et sociales,68,0.22835650480220296,155.2
+Développement des capacités comportementales et relationnelles,Journalisme et communication,68,0.22835650480220296,543.375
+Autres...,"Electricité, électronique (non compris automatisme et productique)",67,0.2249983209080529,687.1666666666666
+Psychologie,"Ressources humaines, gestion du personnel, gestion de l'emploi",66,0.2216401370139029,217.2
+"Coiffure, esthétique et autres spécialités des services aux personnes","Commerce, vente",66,0.2216401370139029,204.58333333333334
+Bâtiment: construction et couverture,"Spécialités pluritechnologiques, génie civil, construction, bois",66,0.2216401370139029,399.57142857142856
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes des échanges et de la gestion,66,0.2216401370139029,244.0
+"Droit, sciences politiques","Informatique, traitement de l'information, réseaux de transmission des données",65,0.21828195311975285,98.375
+"Accueil, hôtellerie, tourisme","Ressources humaines, gestion du personnel, gestion de l'emploi",65,0.21828195311975285,362.9166666666667
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Vie familiale, vie sociale et autres formations au développement personnel",64,0.2149237692256028,68.33333333333333
+"Agro-alimentaire, alimentation, cuisine",Santé,64,0.2149237692256028,346.3076923076923
+"Comptabilité, gestion","Enseignement, formation",64,0.2149237692256028,66.0
+Autres...,Développement des capacités individuelles d'organisation,64,0.2149237692256028,428.25
+"Enseignement, formation",Spécialités plurivalentes de la communication,63,0.21156558533145275,128.5
+Economie,"Finances, banque, assurances",61,0.2048492175431527,0.0
+Economie,"Ressources humaines, gestion du personnel, gestion de l'emploi",61,0.2048492175431527,55.0
+Linguistique,"Ressources humaines, gestion du personnel, gestion de l'emploi",61,0.2048492175431527,169.5
+"Accueil, hôtellerie, tourisme","Enseignement, formation",60,0.20149103364900264,97.66666666666667
+Spécialités plurivalentes de la communication,Spécialités plurivalentes sanitaires et sociales,60,0.20149103364900264,201.8
+Développement des capacités comportementales et relationnelles,"Secrétariat, bureautique",60,0.20149103364900264,216.375
+Autres...,Travail social,60,0.20149103364900264,484.5
+Développement des capacités individuelles d'organisation,Formations générales,59,0.1981328497548526,136.9
+"Agro-alimentaire, alimentation, cuisine","Comptabilité, gestion",59,0.1981328497548526,268.5882352941176
+Autres...,Linguistique,59,0.1981328497548526,209.14285714285714
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes sanitaires et sociales,59,0.1981328497548526,239.25
+"Enseignement, formation","Français, littérature et civilisation françaises",59,0.1981328497548526,167.0
+"Animation culturelle, sportive et de loisirs",Travail social,59,0.1981328497548526,209.125
+Développement des capacités individuelles d'organisation,"Informatique, traitement de l'information, réseaux de transmission des données",59,0.1981328497548526,76.14285714285714
+"Documentation, bibliothèques, administration des données","Informatique, traitement de l'information, réseaux de transmission des données",58,0.19477466586070252,41.0
+"Finances, banque, assurances","Informatique, traitement de l'information, réseaux de transmission des données",58,0.19477466586070252,704.0
+"Enseignement, formation",Linguistique,58,0.19477466586070252,254.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Transport, manutention, magasinage",58,0.19477466586070252,350.0
+Technologies de commandes des transformations industrielles,Technologies industrielles fondamentales,58,0.19477466586070252,330.0
+"Electricité, électronique (non compris automatisme et productique)","Informatique, traitement de l'information, réseaux de transmission des données",57,0.19141648196655248,248.2
+Développement des capacités comportementales et relationnelles,"Finances, banque, assurances",57,0.19141648196655248,293.5
+Bâtiment: construction et couverture,"Mines et carrières, génie civil, topographie",57,0.19141648196655248,358.6
+Développement des capacités comportementales et relationnelles,"Langues vivantes, civilisations étrangères et régionales",57,0.19141648196655248,194.1818181818182
+"Comptabilité, gestion",Spécialités plurivalentes des services,56,0.18805829807240243,79.16666666666667
+Autres...,Journalisme et communication,56,0.18805829807240243,69.4
+"Français, littérature et civilisation françaises",Linguistique,56,0.18805829807240243,162.33333333333334
+"Finances, banque, assurances",Formations générales,56,0.18805829807240243,267.25
+"Agro-alimentaire, alimentation, cuisine","Productions végétales,cultures spécialisées",56,0.18805829807240243,150.0909090909091
+"Langues vivantes, civilisations étrangères et régionales",Spécialités plurivalentes de la communication,56,0.18805829807240243,121.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Spécialités pluridisciplinaires, sciences humaines et droit",56,0.18805829807240243,243.0
+"Comptabilité, gestion",Linguistique,56,0.18805829807240243,93.73333333333333
+"Techniques de l'image et du son, métiers connexes du spectacle",Techniques de l'imprimerie et de l'édition,55,0.1847001141782524,86.5
+"Enseignement, formation","Vie familiale, vie sociale et autres formations au développement personnel",55,0.1847001141782524,218.28571428571428
+"Energie, génie climatique","Spécialités pluritechnologiques, génie civil, construction, bois",55,0.1847001141782524,215.5
+Spécialités plurivalentes des services,"Transport, manutention, magasinage",54,0.18134193028410237,85.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Techniques de l'image et du son, métiers connexes du spectacle",54,0.18134193028410237,24.0
+Spécialités plurivalentes des échanges et de la gestion,Spécialités plurivalentes sanitaires et sociales,54,0.18134193028410237,259.2857142857143
+"Commerce, vente",Moteurs et mécanique auto,53,0.17798374638995232,500.45454545454544
+Formations générales,"Spécialités pluritechnologiques, génie civil, construction, bois",53,0.17798374638995232,225.2
+"Electricité, électronique (non compris automatisme et productique)",Santé,52,0.17462556249580227,531.2857142857143
+"Droit, sciences politiques",Spécialités plurivalentes des échanges et de la gestion,52,0.17462556249580227,275.3333333333333
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes sanitaires et sociales,52,0.17462556249580227,131.2
+"Secrétariat, bureautique","Transport, manutention, magasinage",52,0.17462556249580227,135.66666666666666
+Bâtiment: construction et couverture,"Electricité, électronique (non compris automatisme et productique)",52,0.17462556249580227,772.75
+"Enseignement, formation",Spécialités plurivalentes des échanges et de la gestion,52,0.17462556249580227,162.23076923076923
+"Commerce, vente","Sécurité des biens et des personnes, police, surveillance",52,0.17462556249580227,248.88888888888889
+Formations générales,Spécialités pluriscientifiques,52,0.17462556249580227,85.0
+"Commerce, vente","Productions animales, élevage spécialisé, aquaculture, ...",51,0.17126737860165223,162.66666666666666
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes des échanges et de la gestion,51,0.17126737860165223,395.0
+Autres...,"Droit, sciences politiques",50,0.16790919470750218,65.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités plurivalentes des échanges et de la gestion,50,0.16790919470750218,165.0
+"Droit, sciences politiques","Sciences sociales (y compris démographie, anthropologie)",50,0.16790919470750218,0.0
+Pratiques sportives,Santé,50,0.16790919470750218,679.0
+"Langues vivantes, civilisations étrangères et régionales",Spécialités plurivalentes des échanges et de la gestion,50,0.16790919470750218,95.18181818181819
+Spécialités plurivalentes sanitaires et sociales,"Sécurité des biens et des personnes, police, surveillance",50,0.16790919470750218,352.1
+Journalisme et communication,"Secrétariat, bureautique",49,0.16455101081335213,71.8
+"Secrétariat, bureautique",Spécialités plurivalentes sanitaires et sociales,49,0.16455101081335213,237.66666666666666
+Autres...,Spécialités plurivalentes sanitaires et sociales,48,0.1611928269192021,356.5
+"Electricité, électronique (non compris automatisme et productique)","Enseignement, formation",48,0.1611928269192021,714.0
+"Agro-alimentaire, alimentation, cuisine",Linguistique,48,0.1611928269192021,148.5
+"Energie, génie climatique",Formations générales,48,0.1611928269192021,153.6
+"Enseignement, formation",Journalisme et communication,47,0.15783464302505207,89.0
+"Secrétariat, bureautique",Spécialités plurivalentes des échanges et de la gestion,47,0.15783464302505207,331.77777777777777
+Bâtiment: finitions,"Energie, génie climatique",47,0.15783464302505207,441.8333333333333
+"Musique, arts du spectacle","Techniques de l'image et du son, métiers connexes du spectacle",47,0.15783464302505207,43.666666666666664
+"Commerce, vente",Travail social,47,0.15783464302505207,89.44444444444444
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes sanitaires et sociales,47,0.15783464302505207,171.92307692307693
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Informatique, traitement de l'information, réseaux de transmission des données",46,0.15447645913090202,88.14285714285714
+Psychologie,"Sciences sociales (y compris démographie, anthropologie)",46,0.15447645913090202,416.0
+Développement des capacités comportementales et relationnelles,Pratiques sportives,46,0.15447645913090202,88.0
+"Agro-alimentaire, alimentation, cuisine",Moteurs et mécanique auto,46,0.15447645913090202,180.0
+"Electricité, électronique (non compris automatisme et productique)","Spécialités pluritechnologiques, génie civil, construction, bois",46,0.15447645913090202,748.6666666666666
+Développement des capacités mentales et apprentissages de base,"Ressources humaines, gestion du personnel, gestion de l'emploi",45,0.15111827523675198,368.6666666666667
+Autres...,"Vie familiale, vie sociale et autres formations au développement personnel",45,0.15111827523675198,24.0
+"Droit, sciences politiques","Langues vivantes, civilisations étrangères et régionales",45,0.15111827523675198,76.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités concernant plusieurs capacités,44,0.14776009134260193,176.85714285714286
+"Commerce, vente","Electricité, électronique (non compris automatisme et productique)",44,0.14776009134260193,306.1666666666667
+"Informatique, traitement de l'information, réseaux de transmission des données",Techniques de l'imprimerie et de l'édition,44,0.14776009134260193,402.0
+"Agro-alimentaire, alimentation, cuisine","Transport, manutention, magasinage",44,0.14776009134260193,502.4166666666667
+"Aménagement paysager (parcs, jardins, espaces verts)","Forêts, espaces naturels, faune sauvage, pêche",43,0.14440190744845188,201.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Santé,43,0.14440190744845188,353.2857142857143
+"Agro-alimentaire, alimentation, cuisine","Enseignement, formation",43,0.14440190744845188,272.25
+"Secrétariat, bureautique",Travail social,43,0.14440190744845188,82.36363636363636
+"Habillement (y compris mode, couture)",Textile,42,0.14104372355430184,34.0
+"Commerce, vente","Productions végétales,cultures spécialisées",42,0.14104372355430184,183.125
+"Mines et carrières, génie civil, topographie","Transport, manutention, magasinage",42,0.14104372355430184,771.8333333333334
+"Accueil, hôtellerie, tourisme",Autres...,42,0.14104372355430184,327.5
+"Electricité, électronique (non compris automatisme et productique)","Spécialités plutitechnologiques, mécanique-électricité",42,0.14104372355430184,298.0
+"Animation culturelle, sportive et de loisirs",Formations générales,42,0.14104372355430184,92.55555555555556
+"Aménagement paysager (parcs, jardins, espaces verts)",Formations générales,42,0.14104372355430184,602.1428571428571
+"Sécurité des biens et des personnes, police, surveillance",Travail social,41,0.1376855396601518,261.7142857142857
+Développement des capacités individuelles d'organisation,Spécialités concernant plusieurs capacités,41,0.1376855396601518,224.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Travail social,41,0.1376855396601518,150.33333333333334
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Autres...,41,0.1376855396601518,21.666666666666668
+"Langues vivantes, civilisations étrangères et régionales","Transport, manutention, magasinage",41,0.1376855396601518,129.0
+Journalisme et communication,Techniques de l'imprimerie et de l'édition,41,0.1376855396601518,5.0
+"Mathématiques, statistiques",Physique-chimie,41,0.1376855396601518,0.0
+"Secrétariat, bureautique","Sécurité des biens et des personnes, police, surveillance",41,0.1376855396601518,254.0
+"Animation culturelle, sportive et de loisirs",Santé,41,0.1376855396601518,219.0
+"Comptabilité, gestion",Journalisme et communication,41,0.1376855396601518,117.14285714285714
+"Electricité, électronique (non compris automatisme et productique)","Ressources humaines, gestion du personnel, gestion de l'emploi",41,0.1376855396601518,1715.5
+"Agro-alimentaire, alimentation, cuisine","Productions animales, élevage spécialisé, aquaculture, ...",41,0.1376855396601518,446.42857142857144
+"Droit, sciences politiques",Santé,40,0.13432735576600174,233.5
+Autres...,Spécialités plurivalentes des échanges et de la gestion,40,0.13432735576600174,144.0
+Bâtiment: finitions,"Commerce, vente",40,0.13432735576600174,92.5
+"Spécialités pluritechnologiques, génie civil, construction, bois","Transport, manutention, magasinage",40,0.13432735576600174,1052.75
+"Agro-alimentaire, alimentation, cuisine","Informatique, traitement de l'information, réseaux de transmission des données",40,0.13432735576600174,249.53333333333333
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes sanitaires et sociales,39,0.1309691718718517,59.0
+"Agro-alimentaire, alimentation, cuisine","Nettoyage, assainissement, protection de l'environnement",39,0.1309691718718517,700.5
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes de la communication,39,0.1309691718718517,329.6666666666667
+Linguistique,"Transport, manutention, magasinage",39,0.1309691718718517,258.4166666666667
+Formations générales,"Productions végétales,cultures spécialisées",39,0.1309691718718517,97.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes des services,38,0.12761098797770165,275.6666666666667
+Autres...,"Finances, banque, assurances",38,0.12761098797770165,658.0
+Autres...,Spécialités plurivalentes des services,38,0.12761098797770165,141.0
+Bâtiment: construction et couverture,"Commerce, vente",38,0.12761098797770165,152.0
+"Droit, sciences politiques",Développement des capacités comportementales et relationnelles,38,0.12761098797770165,206.5
+"Sciences sociales (y compris démographie, anthropologie)",Travail social,38,0.12761098797770165,416.0
+Formations générales,Spécialités concernant plusieurs capacités,38,0.12761098797770165,386.0
+"Commerce, vente",Spécialités plurivalentes de l'agronomie et de l'agriculture,38,0.12761098797770165,62.666666666666664
+Développement des capacités mentales et apprentissages de base,Spécialités concernant plusieurs capacités,37,0.1242528040835516,357.6666666666667
+"Comptabilité, gestion",Développement des capacités individuelles d'organisation,37,0.1242528040835516,88.33333333333333
+Autres...,Spécialités concernant plusieurs capacités,37,0.1242528040835516,0.0
+Autres...,Pratiques sportives,37,0.1242528040835516,165.5
+Bâtiment: finitions,Formations générales,37,0.1242528040835516,138.25
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes de la communication,37,0.1242528040835516,1513.0
+Géographie,Histoire,37,0.1242528040835516,0.0
+"Mines et carrières, génie civil, topographie","Spécialités pluritechnologiques, génie civil, construction, bois",37,0.1242528040835516,523.3333333333334
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes de l'agronomie et de l'agriculture,37,0.1242528040835516,333.0
+Formations générales,Spécialités plurivalentes de l'agronomie et de l'agriculture,37,0.1242528040835516,126.14285714285714
+Formations générales,Journalisme et communication,37,0.1242528040835516,99.88888888888889
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités plurivalentes de la communication,36,0.12089462018940156,122.6
+"Enseignement, formation",Spécialités concernant plusieurs capacités,36,0.12089462018940156,322.8
+"Droit, sciences politiques","Enseignement, formation",36,0.12089462018940156,49.25
+"Commerce, vente","Habillement (y compris mode, couture)",36,0.12089462018940156,129.0
+"Commerce, vente","Spécialités plutitechnologiques, mécanique-électricité",36,0.12089462018940156,289.8
+"Accueil, hôtellerie, tourisme",Développement des capacités comportementales et relationnelles,36,0.12089462018940156,471.0
+"Accueil, hôtellerie, tourisme",Formations générales,36,0.12089462018940156,224.85714285714286
+"Secrétariat, bureautique","Techniques de l'image et du son, métiers connexes du spectacle",35,0.11753643629525151,57.666666666666664
+"Comptabilité, gestion",Santé,35,0.11753643629525151,107.8
+Spécialités plurivalentes de la communication,Techniques de l'imprimerie et de l'édition,35,0.11753643629525151,134.33333333333334
+Travail social,"Vie familiale, vie sociale et autres formations au développement personnel",35,0.11753643629525151,66.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Formations générales,35,0.11753643629525151,89.0
+"Animation culturelle, sportive et de loisirs",Développement des capacités comportementales et relationnelles,35,0.11753643629525151,173.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Linguistique,35,0.11753643629525151,298.6666666666667
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes des échanges et de la gestion,34,0.11417825240110148,196.5
+Formations générales,"Vie familiale, vie sociale et autres formations au développement personnel",34,0.11417825240110148,106.625
+"Comptabilité, gestion","Sécurité des biens et des personnes, police, surveillance",34,0.11417825240110148,251.58333333333334
+"Agro-alimentaire, alimentation, cuisine","Secrétariat, bureautique",34,0.11417825240110148,122.11111111111111
+"Documentation, bibliothèques, administration des données","Secrétariat, bureautique",33,0.11082006850695145,41.0
+Développement des capacités individuelles d'organisation,"Secrétariat, bureautique",33,0.11082006850695145,49.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Journalisme et communication,33,0.11082006850695145,0.0
+"Energie, génie climatique",Technologies industrielles fondamentales,33,0.11082006850695145,345.3333333333333
+Psychologie,"Spécialités pluridisciplinaires, sciences humaines et droit",33,0.11082006850695145,246.33333333333334
+Santé,"Vie familiale, vie sociale et autres formations au développement personnel",33,0.11082006850695145,719.6666666666666
+"Français, littérature et civilisation françaises","Informatique, traitement de l'information, réseaux de transmission des données",33,0.11082006850695145,137.14285714285714
+Economie,"Spécialités pluridisciplinaires, sciences humaines et droit",33,0.11082006850695145,99.5
+"Français, littérature et civilisation françaises","Secrétariat, bureautique",33,0.11082006850695145,160.0
+Développement des capacités comportementales et relationnelles,"Musique, arts du spectacle",33,0.11082006850695145,69.0
+"Comptabilité, gestion","Spécialités pluridisciplinaires, sciences humaines et droit",33,0.11082006850695145,279.625
+"Electricité, électronique (non compris automatisme et productique)",Technologies de commandes des transformations industrielles,33,0.11082006850695145,228.9
+"Animation culturelle, sportive et de loisirs",Spécialités plurivalentes sanitaires et sociales,33,0.11082006850695145,134.2
+Développement des capacités individuelles d'organisation,"Vie familiale, vie sociale et autres formations au développement personnel",32,0.1074618846128014,70.5
+Autres...,"Techniques de l'image et du son, métiers connexes du spectacle",32,0.1074618846128014,35.5
+Bâtiment: finitions,"Spécialités pluritechnologiques, génie civil, construction, bois",32,0.1074618846128014,159.75
+Autres...,Economie,32,0.1074618846128014,73.0
+Développement des capacités mentales et apprentissages de base,Santé,32,0.1074618846128014,408.25
+Linguistique,Spécialités plurivalentes des échanges et de la gestion,32,0.1074618846128014,113.2
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Secrétariat, bureautique",32,0.1074618846128014,365.0
+Formations générales,Pratiques sportives,32,0.1074618846128014,57.5
+"Aménagement paysager (parcs, jardins, espaces verts)","Productions animales, élevage spécialisé, aquaculture, ...",32,0.1074618846128014,179.33333333333334
+"Langues vivantes, civilisations étrangères et régionales",Technologies industrielles fondamentales,32,0.1074618846128014,1635.5
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Sciences sociales (y compris démographie, anthropologie)",31,0.10410370071865137,0.0
+Spécialités plurivalentes des services,Spécialités plurivalentes sanitaires et sociales,31,0.10410370071865137,430.6
+"Animation culturelle, sportive et de loisirs",Autres...,31,0.10410370071865137,84.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes des échanges et de la gestion,31,0.10410370071865137,62.8
+Bâtiment: finitions,"Electricité, électronique (non compris automatisme et productique)",31,0.10410370071865137,284.25
+"Commerce, vente","Français, littérature et civilisation françaises",31,0.10410370071865137,152.66666666666666
+"Forêts, espaces naturels, faune sauvage, pêche","Productions végétales,cultures spécialisées",31,0.10410370071865137,157.66666666666666
+"Aménagement paysager (parcs, jardins, espaces verts)","Commerce, vente",31,0.10410370071865137,77.5
+"Forêts, espaces naturels, faune sauvage, pêche",Spécialités plurivalentes de l'agronomie et de l'agriculture,31,0.10410370071865137,971.0
+"Secrétariat, bureautique",Techniques de l'imprimerie et de l'édition,31,0.10410370071865137,81.2
+"Agro-alimentaire, alimentation, cuisine","Aménagement paysager (parcs, jardins, espaces verts)",31,0.10410370071865137,158.0
+"Electricité, électronique (non compris automatisme et productique)",Moteurs et mécanique auto,30,0.10074551682450132,492.4
+Formations générales,"Productions animales, élevage spécialisé, aquaculture, ...",30,0.10074551682450132,100.66666666666667
+Economie,"Sciences sociales (y compris démographie, anthropologie)",30,0.10074551682450132,0.0
+Autres...,Bâtiment: construction et couverture,30,0.10074551682450132,150.85714285714286
+"Commerce, vente",Technologies industrielles fondamentales,30,0.10074551682450132,78.0
+Spécialités plurivalentes des échanges et de la gestion,Technologies industrielles fondamentales,30,0.10074551682450132,67.0
+Formations générales,"Spécialités plutitechnologiques, mécanique-électricité",29,0.09738733293035126,333.25
+"Droit, sciences politiques",Psychologie,29,0.09738733293035126,908.5
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes sanitaires et sociales,29,0.09738733293035126,414.5
+Autres...,"Nettoyage, assainissement, protection de l'environnement",29,0.09738733293035126,424.14285714285717
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Vie familiale, vie sociale et autres formations au développement personnel",29,0.09738733293035126,117.33333333333333
+"Animation culturelle, sportive et de loisirs","Commerce, vente",29,0.09738733293035126,0.0
+Spécialités plurivalentes des services,Technologies industrielles fondamentales,29,0.09738733293035126,356.3333333333333
+"Droit, sciences politiques",Linguistique,29,0.09738733293035126,0.0
+"Comptabilité, gestion",Spécialités plurivalentes sanitaires et sociales,29,0.09738733293035126,117.5
+Pratiques sportives,Spécialités concernant plusieurs capacités,28,0.09402914903620122,267.0
+Développement des capacités mentales et apprentissages de base,"Informatique, traitement de l'information, réseaux de transmission des données",28,0.09402914903620122,398.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités plurivalentes de la communication,28,0.09402914903620122,228.0
+"Nettoyage, assainissement, protection de l'environnement","Ressources humaines, gestion du personnel, gestion de l'emploi",28,0.09402914903620122,459.55555555555554
+"Informatique, traitement de l'information, réseaux de transmission des données",Travail social,28,0.09402914903620122,88.0
+Développement des capacités mentales et apprentissages de base,Pratiques sportives,28,0.09402914903620122,0.0
+"Commerce, vente",Développement des capacités mentales et apprentissages de base,28,0.09402914903620122,127.0
+Développement des capacités mentales et apprentissages de base,Travail social,28,0.09402914903620122,388.2857142857143
+"Forêts, espaces naturels, faune sauvage, pêche","Productions animales, élevage spécialisé, aquaculture, ...",28,0.09402914903620122,214.33333333333334
+Formations générales,Technologies de commandes des transformations industrielles,28,0.09402914903620122,142.16666666666666
+"Enseignement, formation",Spécialités plurivalentes des services,27,0.09067096514205118,44.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Santé,27,0.09067096514205118,164.66666666666666
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités plurivalentes sanitaires et sociales,27,0.09067096514205118,581.0
+"Droit, sciences politiques",Travail social,27,0.09067096514205118,0.0
+Développement des capacités comportementales et relationnelles,"Sciences sociales (y compris démographie, anthropologie)",27,0.09067096514205118,42.0
+Développement des capacités comportementales et relationnelles,"Spécialités pluridisciplinaires, sciences humaines et droit",27,0.09067096514205118,185.55555555555554
+"Enseignement, formation","Spécialités pluridisciplinaires, sciences humaines et droit",27,0.09067096514205118,159.8
+"Français, littérature et civilisation françaises","Mathématiques, statistiques",27,0.09067096514205118,255.0
+Formations générales,"Sciences sociales (y compris démographie, anthropologie)",27,0.09067096514205118,115.0
+Développement des capacités comportementales et relationnelles,"Transport, manutention, magasinage",27,0.09067096514205118,473.3333333333333
+Formations générales,"Mines et carrières, génie civil, topographie",27,0.09067096514205118,363.6666666666667
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités concernant plusieurs capacités,26,0.08731278124790114,166.5
+"Agro-alimentaire, alimentation, cuisine",Bâtiment: construction et couverture,26,0.08731278124790114,408.3333333333333
+"Informatique, traitement de l'information, réseaux de transmission des données",Technologies de commandes des transformations industrielles,26,0.08731278124790114,135.83333333333334
+"Commerce, vente","Energie, génie climatique",26,0.08731278124790114,423.6666666666667
+Formations générales,"Nettoyage, assainissement, protection de l'environnement",26,0.08731278124790114,518.0
+Psychologie,"Vie familiale, vie sociale et autres formations au développement personnel",26,0.08731278124790114,80.5
+"Spécialités plutitechnologiques, mécanique-électricité",Technologies industrielles fondamentales,26,0.08731278124790114,125.0
+Linguistique,Spécialités plurivalentes de la communication,26,0.08731278124790114,45.2
+"Commerce, vente","Spécialités pluridisciplinaires, sciences humaines et droit",26,0.08731278124790114,123.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités pluriscientifiques,26,0.08731278124790114,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Développement des capacités comportementales et relationnelles,25,0.08395459735375109,0.0
+Développement des capacités comportementales et relationnelles,Linguistique,25,0.08395459735375109,62.666666666666664
+Bâtiment: construction et couverture,Travail du bois et de l'ameublement,25,0.08395459735375109,0.0
+Bâtiment: finitions,Travail du bois et de l'ameublement,25,0.08395459735375109,213.0
+Santé,Sciences de la vie,25,0.08395459735375109,106.0
+"Droit, sciences politiques","Secrétariat, bureautique",25,0.08395459735375109,83.66666666666667
+Economie,Formations générales,25,0.08395459735375109,838.5
+Développement des capacités individuelles d'organisation,Spécialités plurivalentes de la communication,25,0.08395459735375109,223.33333333333334
+"Energie, génie climatique","Spécialités plutitechnologiques, mécanique-électricité",25,0.08395459735375109,136.0
+Autres...,"Français, littérature et civilisation françaises",25,0.08395459735375109,28.0
+"Enseignement, formation","Nettoyage, assainissement, protection de l'environnement",25,0.08395459735375109,130.0
+"Animation culturelle, sportive et de loisirs","Sécurité des biens et des personnes, police, surveillance",25,0.08395459735375109,42.0
+"Mécanique générale et de précision, usinage","Spécialités plutitechnologiques, mécanique-électricité",25,0.08395459735375109,276.6666666666667
+Développement des capacités individuelles d'organisation,"Sécurité des biens et des personnes, police, surveillance",25,0.08395459735375109,260.5
+"Comptabilité, gestion","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",25,0.08395459735375109,93.0
+Formations générales,"Musique, arts du spectacle",25,0.08395459735375109,104.2
+"Enseignement, formation","Finances, banque, assurances",24,0.08059641345960104,0.0
+"Commerce, vente",Spécialités concernant plusieurs capacités,24,0.08059641345960104,342.57142857142856
+"Sciences sociales (y compris démographie, anthropologie)","Spécialités pluridisciplinaires, sciences humaines et droit",24,0.08059641345960104,18.5
+"Enseignement, formation","Musique, arts du spectacle",24,0.08059641345960104,103.6
+"Langues vivantes, civilisations étrangères et régionales",Spécialités littéraires et artistiques plurivalentes,24,0.08059641345960104,0.0
+Psychologie,Spécialités plurivalentes sanitaires et sociales,24,0.08059641345960104,135.0
+Bâtiment: construction et couverture,"Informatique, traitement de l'information, réseaux de transmission des données",24,0.08059641345960104,108.25
+"Commerce, vente",Pratiques sportives,24,0.08059641345960104,41.5
+"Informatique, traitement de l'information, réseaux de transmission des données","Nettoyage, assainissement, protection de l'environnement",24,0.08059641345960104,203.75
+"Spécialités plutitechnologiques, mécanique-électricité",Technologies de commandes des transformations industrielles,24,0.08059641345960104,236.0
+Développement des capacités mentales et apprentissages de base,Formations générales,24,0.08059641345960104,281.5
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Commerce, vente",24,0.08059641345960104,37.0
+"Français, littérature et civilisation françaises",Géographie,24,0.08059641345960104,0.0
+"Français, littérature et civilisation françaises",Histoire,24,0.08059641345960104,0.0
+"Comptabilité, gestion",Travail social,24,0.08059641345960104,174.57142857142858
+"Electricité, électronique (non compris automatisme et productique)","Mines et carrières, génie civil, topographie",24,0.08059641345960104,685.0
+Autres...,"Energie, génie climatique",23,0.07723822956545101,359.6666666666667
+"Electricité, électronique (non compris automatisme et productique)",Technologies industrielles fondamentales,23,0.07723822956545101,417.5
+"Commerce, vente","Techniques de l'image et du son, métiers connexes du spectacle",23,0.07723822956545101,13.0
+Santé,Spécialités plurivalentes des échanges et de la gestion,23,0.07723822956545101,308.5
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes des échanges et de la gestion,23,0.07723822956545101,220.0
+Formations générales,"Techniques de l'image et du son, métiers connexes du spectacle",23,0.07723822956545101,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes des échanges et de la gestion,23,0.07723822956545101,3563.0
+"Chimie-biologie, biochimie",Spécialités pluriscientifiques,23,0.07723822956545101,0.0
+"Electricité, électronique (non compris automatisme et productique)","Mécanique générale et de précision, usinage",23,0.07723822956545101,101.75
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Spécialités plurivalentes sanitaires et sociales,23,0.07723822956545101,52.0
+"Electricité, électronique (non compris automatisme et productique)","Langues vivantes, civilisations étrangères et régionales",23,0.07723822956545101,144.33333333333334
+"Finances, banque, assurances",Spécialités plurivalentes de la communication,23,0.07723822956545101,475.25
+Autres...,"Productions animales, élevage spécialisé, aquaculture, ...",22,0.07388004567130096,67.0
+Jeux et activités spécifiques de loisirs,Pratiques sportives,22,0.07388004567130096,0.0
+Spécialités pluriscientifiques,Technologies industrielles fondamentales,22,0.07388004567130096,496.5
+Développement des capacités individuelles d'organisation,Santé,22,0.07388004567130096,362.25
+"Aménagement du territoire, développement, urbanisme",Bâtiment: construction et couverture,22,0.07388004567130096,136.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Psychologie,22,0.07388004567130096,133.0
+"Mécanique générale et de précision, usinage",Technologies industrielles fondamentales,22,0.07388004567130096,407.5
+Spécialités plurivalentes des échanges et de la gestion,"Sécurité des biens et des personnes, police, surveillance",22,0.07388004567130096,269.77777777777777
+"Electricité, électronique (non compris automatisme et productique)",Structures métalliques,22,0.07388004567130096,135.66666666666666
+Economie,Spécialités plurivalentes des échanges et de la gestion,22,0.07388004567130096,241.5
+Développement des capacités individuelles d'organisation,Spécialités plurivalentes des échanges et de la gestion,22,0.07388004567130096,318.0
+"Agro-alimentaire, alimentation, cuisine","Electricité, électronique (non compris automatisme et productique)",22,0.07388004567130096,347.3333333333333
+Bâtiment: construction et couverture,"Comptabilité, gestion",21,0.07052186177715092,103.0
+Bâtiment: construction et couverture,"Ressources humaines, gestion du personnel, gestion de l'emploi",21,0.07052186177715092,275.14285714285717
+Formations générales,"Mécanique générale et de précision, usinage",21,0.07052186177715092,277.3333333333333
+"Energie, génie climatique",Technologies de commandes des transformations industrielles,21,0.07052186177715092,343.0
+"Accueil, hôtellerie, tourisme","Langues vivantes, civilisations étrangères et régionales",21,0.07052186177715092,304.3333333333333
+Economie,"Enseignement, formation",21,0.07052186177715092,1145.0
+"Agro-alimentaire, alimentation, cuisine",Développement des capacités comportementales et relationnelles,21,0.07052186177715092,200.33333333333334
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Enseignement, formation",21,0.07052186177715092,6.0
+"Agro-alimentaire, alimentation, cuisine",Bâtiment: finitions,21,0.07052186177715092,123.0
+"Energie, génie climatique","Sécurité des biens et des personnes, police, surveillance",20,0.06716367788300087,267.3333333333333
+"Finances, banque, assurances","Secrétariat, bureautique",20,0.06716367788300087,127.0
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes des services,20,0.06716367788300087,334.0
+"Accueil, hôtellerie, tourisme","Animation culturelle, sportive et de loisirs",20,0.06716367788300087,8.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Vie familiale, vie sociale et autres formations au développement personnel",20,0.06716367788300087,92.0
+Spécialités pluritechnologiques des transformations,Technologies industrielles fondamentales,20,0.06716367788300087,66.0
+Autres...,Psychologie,20,0.06716367788300087,733.0
+Sciences de la vie,Sciences naturelles (Biologie-Géologie),20,0.06716367788300087,0.0
+"Commerce, vente","Mécanique générale et de précision, usinage",20,0.06716367788300087,170.5
+"Français, littérature et civilisation françaises","Ressources humaines, gestion du personnel, gestion de l'emploi",20,0.06716367788300087,38.333333333333336
+Santé,Spécialités plurivalentes de la communication,20,0.06716367788300087,131.5
+"Informatique, traitement de l'information, réseaux de transmission des données",Technologies industrielles fondamentales,20,0.06716367788300087,241.5
+"Agro-alimentaire, alimentation, cuisine","Energie, génie climatique",20,0.06716367788300087,192.8
+"Informatique, traitement de l'information, réseaux de transmission des données","Spécialités pluridisciplinaires, sciences humaines et droit",20,0.06716367788300087,144.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes sanitaires et sociales,20,0.06716367788300087,72.5
+"Electricité, électronique (non compris automatisme et productique)","Secrétariat, bureautique",20,0.06716367788300087,216.0
+Moteurs et mécanique auto,Structures métalliques,20,0.06716367788300087,340.0
+"Langues vivantes, civilisations étrangères et régionales","Sécurité des biens et des personnes, police, surveillance",20,0.06716367788300087,243.0
+"Electricité, électronique (non compris automatisme et productique)",Linguistique,20,0.06716367788300087,429.3333333333333
+"Commerce, vente",Techniques de l'imprimerie et de l'édition,19,0.06380549398885083,184.33333333333334
+"Accueil, hôtellerie, tourisme","Informatique, traitement de l'information, réseaux de transmission des données",19,0.06380549398885083,242.0
+Journalisme et communication,"Musique, arts du spectacle",19,0.06380549398885083,26.0
+"Chimie-biologie, biochimie",Sciences de la vie,19,0.06380549398885083,0.0
+"Droit, sciences politiques","Sécurité des biens et des personnes, police, surveillance",19,0.06380549398885083,180.2
+"Enseignement, formation","Sciences sociales (y compris démographie, anthropologie)",19,0.06380549398885083,0.0
+"Mécanique générale et de précision, usinage",Technologies de commandes des transformations industrielles,19,0.06380549398885083,172.33333333333334
+"Musique, arts du spectacle",Spécialités plurivalentes de la communication,19,0.06380549398885083,44.25
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Techniques de l'imprimerie et de l'édition,19,0.06380549398885083,0.0
+Développement des capacités mentales et apprentissages de base,Psychologie,19,0.06380549398885083,365.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes des services,19,0.06380549398885083,293.4
+"Accueil, hôtellerie, tourisme",Santé,19,0.06380549398885083,234.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Développement des capacités comportementales et relationnelles,19,0.06380549398885083,87.0
+Développement des capacités individuelles d'organisation,Travail social,19,0.06380549398885083,692.0
+"Français, littérature et civilisation françaises",Spécialités plurivalentes de la communication,19,0.06380549398885083,32.5
+"Energie, génie climatique","Transport, manutention, magasinage",19,0.06380549398885083,307.75
+Formations générales,Moteurs et mécanique auto,19,0.06380549398885083,323.25
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Langues vivantes, civilisations étrangères et régionales",19,0.06380549398885083,77.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Secrétariat, bureautique",19,0.06380549398885083,9.5
+"Droit, sciences politiques",Spécialités plurivalentes de la communication,19,0.06380549398885083,134.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Technologies industrielles fondamentales,19,0.06380549398885083,86.0
+"Agro-alimentaire, alimentation, cuisine","Coiffure, esthétique et autres spécialités des services aux personnes",19,0.06380549398885083,69.0
+"Agro-alimentaire, alimentation, cuisine","Droit, sciences politiques",19,0.06380549398885083,82.33333333333333
+"Spécialités plutitechnologiques, mécanique-électricité",Structures métalliques,19,0.06380549398885083,41.0
+Bâtiment: construction et couverture,"Secrétariat, bureautique",18,0.06044731009470078,166.2
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Transport, manutention, magasinage",18,0.06044731009470078,58.0
+Economie,"Mathématiques, statistiques",18,0.06044731009470078,0.0
+"Finances, banque, assurances",Spécialités plurivalentes des services,18,0.06044731009470078,22.0
+Santé,"Sciences sociales (y compris démographie, anthropologie)",18,0.06044731009470078,0.0
+"Mathématiques, statistiques",Physique,18,0.06044731009470078,0.0
+"Animation culturelle, sportive et de loisirs","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",18,0.06044731009470078,102.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Informatique, traitement de l'information, réseaux de transmission des données",18,0.06044731009470078,10.0
+Spécialités concernant plusieurs capacités,"Spécialités pluridisciplinaires, sciences humaines et droit",18,0.06044731009470078,200.0
+"Langues vivantes, civilisations étrangères et régionales",Spécialités plurivalentes des services,18,0.06044731009470078,126.75
+Bâtiment: finitions,"Mines et carrières, génie civil, topographie",18,0.06044731009470078,93.5
+"Accueil, hôtellerie, tourisme",Journalisme et communication,18,0.06044731009470078,31.0
+Autres...,Techniques de l'imprimerie et de l'édition,18,0.06044731009470078,0.0
+Développement des capacités comportementales et relationnelles,Economie,18,0.06044731009470078,0.0
+"Finances, banque, assurances","Transport, manutention, magasinage",18,0.06044731009470078,37.5
+Economie,"Informatique, traitement de l'information, réseaux de transmission des données",18,0.06044731009470078,51.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités pluritechnologiques des transformations,18,0.06044731009470078,315.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Bâtiment: construction et couverture,18,0.06044731009470078,205.5
+"Langues vivantes, civilisations étrangères et régionales",Santé,18,0.06044731009470078,285.0
+"Chimie-biologie, biochimie",Formations générales,18,0.06044731009470078,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités plurivalentes sanitaires et sociales,18,0.06044731009470078,0.0
+Bâtiment: finitions,"Transport, manutention, magasinage",18,0.06044731009470078,0.0
+Moteurs et mécanique auto,"Spécialités plutitechnologiques, mécanique-électricité",17,0.05708912620055074,0.0
+"Nettoyage, assainissement, protection de l'environnement",Santé,17,0.05708912620055074,276.25
+Application des droits et statuts des personnes,"Ressources humaines, gestion du personnel, gestion de l'emploi",17,0.05708912620055074,618.0
+Linguistique,"Spécialités pluridisciplinaires, sciences humaines et droit",17,0.05708912620055074,319.0
+Développement des capacités mentales et apprentissages de base,"Langues vivantes, civilisations étrangères et régionales",17,0.05708912620055074,199.0
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes sanitaires et sociales,17,0.05708912620055074,56.0
+"Animation culturelle, sportive et de loisirs","Informatique, traitement de l'information, réseaux de transmission des données",17,0.05708912620055074,120.0
+Développement des capacités comportementales et relationnelles,"Nettoyage, assainissement, protection de l'environnement",17,0.05708912620055074,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités pluriscientifiques,17,0.05708912620055074,1222.0
+Spécialités littéraires et artistiques plurivalentes,"Spécialités pluridisciplinaires, sciences humaines et droit",17,0.05708912620055074,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Technologies industrielles fondamentales,17,0.05708912620055074,983.0
+"Animation culturelle, sportive et de loisirs","Ressources humaines, gestion du personnel, gestion de l'emploi",17,0.05708912620055074,90.5
+"Secrétariat, bureautique",Spécialités plurivalentes des services,17,0.05708912620055074,11.5
+"Chimie-biologie, biochimie",Santé,17,0.05708912620055074,362.0
+Journalisme et communication,"Langues vivantes, civilisations étrangères et régionales",17,0.05708912620055074,129.75
+Santé,Spécialités plurivalentes des services,17,0.05708912620055074,40.666666666666664
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Sécurité des biens et des personnes, police, surveillance",17,0.05708912620055074,76.5
+"Spécialités pluritechnologiques, génie civil, construction, bois","Spécialités plutitechnologiques, mécanique-électricité",17,0.05708912620055074,0.0
+"Commerce, vente","Nettoyage, assainissement, protection de l'environnement",17,0.05708912620055074,129.0
+Spécialités concernant plusieurs capacités,Travail social,17,0.05708912620055074,403.0
+Pratiques sportives,"Sécurité des biens et des personnes, police, surveillance",17,0.05708912620055074,453.75
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités plurivalentes sanitaires et sociales,17,0.05708912620055074,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Ressources humaines, gestion du personnel, gestion de l'emploi",17,0.05708912620055074,326.6
+Arts plastiques,Formations générales,17,0.05708912620055074,51.0
+"Langues vivantes, civilisations étrangères et régionales","Spécialités pluridisciplinaires, sciences humaines et droit",17,0.05708912620055074,159.33333333333334
+"Spécialités pluritechnologiques, génie civil, construction, bois",Technologies industrielles fondamentales,17,0.05708912620055074,0.0
+"Agro-alimentaire, alimentation, cuisine",Travail social,17,0.05708912620055074,72.0
+Autres...,"Musique, arts du spectacle",16,0.0537309423064007,55.5
+Développement des capacités mentales et apprentissages de base,"Secrétariat, bureautique",16,0.0537309423064007,77.66666666666667
+"Commerce, vente",Textile,16,0.0537309423064007,357.0
+"Commerce, vente","Sciences sociales (y compris démographie, anthropologie)",16,0.0537309423064007,137.0
+"Accueil, hôtellerie, tourisme","Transport, manutention, magasinage",16,0.0537309423064007,184.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités littéraires et artistiques plurivalentes,16,0.0537309423064007,0.0
+"Français, littérature et civilisation françaises",Spécialités littéraires et artistiques plurivalentes,16,0.0537309423064007,0.0
+"Droit, sciences politiques",Développement des capacités individuelles d'organisation,16,0.0537309423064007,122.0
+Formations générales,"Mathématiques, statistiques",16,0.0537309423064007,255.0
+"Accueil, hôtellerie, tourisme","Secrétariat, bureautique",16,0.0537309423064007,182.5
+"Droit, sciences politiques",Journalisme et communication,16,0.0537309423064007,56.0
+Journalisme et communication,Linguistique,16,0.0537309423064007,0.0
+Linguistique,"Sécurité des biens et des personnes, police, surveillance",16,0.0537309423064007,249.28571428571428
+"Aménagement paysager (parcs, jardins, espaces verts)","Nettoyage, assainissement, protection de l'environnement",16,0.0537309423064007,541.0
+"Mathématiques, statistiques",Spécialités pluriscientifiques,16,0.0537309423064007,29.0
+"Finances, banque, assurances",Journalisme et communication,16,0.0537309423064007,267.3333333333333
+"Accueil, hôtellerie, tourisme","Nettoyage, assainissement, protection de l'environnement",16,0.0537309423064007,293.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Transport, manutention, magasinage",16,0.0537309423064007,1446.0
+"Nettoyage, assainissement, protection de l'environnement","Transport, manutention, magasinage",16,0.0537309423064007,259.5
+Développement des capacités comportementales et relationnelles,Technologies industrielles fondamentales,16,0.0537309423064007,96.8
+"Comptabilité, gestion","Spécialités pluritechnologiques, génie civil, construction, bois",16,0.0537309423064007,136.33333333333334
+"Spécialités pluritechnologiques, génie civil, construction, bois","Sécurité des biens et des personnes, police, surveillance",16,0.0537309423064007,396.57142857142856
+"Agro-alimentaire, alimentation, cuisine","Français, littérature et civilisation françaises",16,0.0537309423064007,266.3333333333333
+Chimie,Formations générales,16,0.0537309423064007,719.0
+"Agro-alimentaire, alimentation, cuisine","Spécialités plutitechnologiques, mécanique-électricité",16,0.0537309423064007,48.0
+Spécialités plurivalentes des échanges et de la gestion,"Spécialités plutitechnologiques, mécanique-électricité",16,0.0537309423064007,18.0
+Spécialités concernant plusieurs capacités,"Sécurité des biens et des personnes, police, surveillance",15,0.05037275841225066,261.6666666666667
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes des échanges et de la gestion,15,0.05037275841225066,37.5
+"Energie, génie climatique","Enseignement, formation",15,0.05037275841225066,0.0
+"Comptabilité, gestion","Mathématiques, statistiques",15,0.05037275841225066,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Technologies de commandes des transformations industrielles,15,0.05037275841225066,194.5
+"Enseignement, formation","Techniques de l'image et du son, métiers connexes du spectacle",15,0.05037275841225066,46.666666666666664
+"Aménagement du territoire, développement, urbanisme","Droit, sciences politiques",15,0.05037275841225066,84.0
+Autres...,Bâtiment: finitions,15,0.05037275841225066,663.0
+"Energie, génie climatique","Nettoyage, assainissement, protection de l'environnement",15,0.05037275841225066,78.66666666666667
+"Aménagement paysager (parcs, jardins, espaces verts)",Bâtiment: finitions,15,0.05037275841225066,68.66666666666667
+"Comptabilité, gestion","Electricité, électronique (non compris automatisme et productique)",15,0.05037275841225066,100.0
+Arts plastiques,Techniques de l'imprimerie et de l'édition,15,0.05037275841225066,0.0
+Autres...,"Sciences sociales (y compris démographie, anthropologie)",15,0.05037275841225066,0.0
+"Commerce, vente","Mathématiques, statistiques",15,0.05037275841225066,0.0
+"Langues vivantes, civilisations étrangères et régionales","Techniques de l'image et du son, métiers connexes du spectacle",15,0.05037275841225066,76.5
+Application des droits et statuts des personnes,Développement des capacités comportementales et relationnelles,15,0.05037275841225066,236.5
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes des services,15,0.05037275841225066,0.0
+Spécialités concernant plusieurs capacités,"Vie familiale, vie sociale et autres formations au développement personnel",15,0.05037275841225066,23.0
+"Aménagement du territoire, développement, urbanisme",Autres...,15,0.05037275841225066,0.0
+Développement des capacités mentales et apprentissages de base,"Vie familiale, vie sociale et autres formations au développement personnel",15,0.05037275841225066,280.0
+"Aménagement du territoire, développement, urbanisme","Ressources humaines, gestion du personnel, gestion de l'emploi",15,0.05037275841225066,106.5
+Développement des capacités mentales et apprentissages de base,"Français, littérature et civilisation françaises",15,0.05037275841225066,372.0
+"Accueil, hôtellerie, tourisme","Sécurité des biens et des personnes, police, surveillance",15,0.05037275841225066,326.0
+Développement des capacités mentales et apprentissages de base,Linguistique,15,0.05037275841225066,279.5
+Spécialités plurivalentes des services,"Sécurité des biens et des personnes, police, surveillance",15,0.05037275841225066,83.0
+"Animation culturelle, sportive et de loisirs",Jeux et activités spécifiques de loisirs,15,0.05037275841225066,73.5
+Formations générales,"Habillement (y compris mode, couture)",15,0.05037275841225066,35.5
+"Informatique, traitement de l'information, réseaux de transmission des données","Mécanique générale et de précision, usinage",15,0.05037275841225066,0.0
+"Commerce, vente",Technologies de commandes des transformations industrielles,15,0.05037275841225066,93.0
+Santé,"Spécialités pluridisciplinaires, sciences humaines et droit",15,0.05037275841225066,119.0
+"Accueil, hôtellerie, tourisme","Comptabilité, gestion",15,0.05037275841225066,622.5
+Développement des capacités comportementales et relationnelles,"Français, littérature et civilisation françaises",15,0.05037275841225066,131.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Langues vivantes, civilisations étrangères et régionales",15,0.05037275841225066,23.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Journalisme et communication,15,0.05037275841225066,110.0
+Bâtiment: construction et couverture,"Sécurité des biens et des personnes, police, surveillance",15,0.05037275841225066,554.5
+Moteurs et mécanique auto,"Transport, manutention, magasinage",15,0.05037275841225066,118.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Sécurité des biens et des personnes, police, surveillance",15,0.05037275841225066,608.0
+"Commerce, vente","Spécialités pluritechnologiques, génie civil, construction, bois",15,0.05037275841225066,0.0
+Santé,Spécialités pluriscientifiques,14,0.04701457451810061,78.66666666666667
+Autres...,"Spécialités pluridisciplinaires, sciences humaines et droit",14,0.04701457451810061,163.0
+Autres...,"Productions végétales,cultures spécialisées",14,0.04701457451810061,176.66666666666666
+"Accueil, hôtellerie, tourisme",Travail social,14,0.04701457451810061,74.0
+"Animation culturelle, sportive et de loisirs",Autres disciplines artistiques et spécialités artistiques plurivalentes,14,0.04701457451810061,3.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités plurivalentes de la communication,14,0.04701457451810061,0.0
+"Energie, génie climatique","Informatique, traitement de l'information, réseaux de transmission des données",14,0.04701457451810061,236.0
+Autres...,Technologies industrielles fondamentales,14,0.04701457451810061,263.0
+Autres...,"Mathématiques, statistiques",14,0.04701457451810061,256.0
+Bâtiment: finitions,"Comptabilité, gestion",14,0.04701457451810061,62.5
+Physique-chimie,Spécialités pluriscientifiques,14,0.04701457451810061,0.0
+"Comptabilité, gestion","Energie, génie climatique",14,0.04701457451810061,133.0
+"Animation culturelle, sportive et de loisirs",Développement des capacités individuelles d'organisation,14,0.04701457451810061,375.0
+Bâtiment: construction et couverture,"Droit, sciences politiques",14,0.04701457451810061,135.0
+"Comptabilité, gestion","Nettoyage, assainissement, protection de l'environnement",14,0.04701457451810061,426.3333333333333
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités plurivalentes des services,14,0.04701457451810061,551.0
+"Mécanique générale et de précision, usinage",Structures métalliques,14,0.04701457451810061,130.0
+"Sécurité des biens et des personnes, police, surveillance","Vie familiale, vie sociale et autres formations au développement personnel",14,0.04701457451810061,251.33333333333334
+Formations générales,Spécialités littéraires et artistiques plurivalentes,14,0.04701457451810061,0.0
+Arts plastiques,"Informatique, traitement de l'information, réseaux de transmission des données",14,0.04701457451810061,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Français, littérature et civilisation françaises",14,0.04701457451810061,362.25
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes de la communication,14,0.04701457451810061,171.0
+Spécialités plurivalentes de la communication,"Sécurité des biens et des personnes, police, surveillance",14,0.04701457451810061,560.5
+Linguistique,Travail social,14,0.04701457451810061,198.66666666666666
+Formations générales,Physique-chimie,14,0.04701457451810061,390.0
+"Droit, sciences politiques","Français, littérature et civilisation françaises",14,0.04701457451810061,105.0
+"Energie, génie climatique",Spécialités plurivalentes des échanges et de la gestion,14,0.04701457451810061,1963.5
+"Comptabilité, gestion",Spécialités plurivalentes de l'agronomie et de l'agriculture,14,0.04701457451810061,165.5
+"Energie, génie climatique","Langues vivantes, civilisations étrangères et régionales",14,0.04701457451810061,161.2
+Autres...,Spécialités plurivalentes de l'agronomie et de l'agriculture,14,0.04701457451810061,138.25
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes sanitaires et sociales,14,0.04701457451810061,173.66666666666666
+"Langues vivantes, civilisations étrangères et régionales","Spécialités pluritechnologiques, génie civil, construction, bois",14,0.04701457451810061,195.5
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Spécialités plurivalentes des échanges et de la gestion,14,0.04701457451810061,128.33333333333334
+Linguistique,Spécialités plurivalentes sanitaires et sociales,14,0.04701457451810061,208.0
+Economie,Géographie,13,0.04365639062395057,0.0
+"Commerce, vente",Psychologie,13,0.04365639062395057,228.0
+"Accueil, hôtellerie, tourisme","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",13,0.04365639062395057,98.0
+"Droit, sciences politiques","Philosophie, éthique et théologie",13,0.04365639062395057,32.0
+Bâtiment: construction et couverture,"Enseignement, formation",13,0.04365639062395057,1223.5
+"Agro-alimentaire, alimentation, cuisine","Chimie-biologie, biochimie",13,0.04365639062395057,51.0
+Sciences de la terre,Sciences de la vie,13,0.04365639062395057,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités plurivalentes de la communication,13,0.04365639062395057,69.0
+"Comptabilité, gestion","Productions végétales,cultures spécialisées",13,0.04365639062395057,175.0
+"Musique, arts du spectacle",Spécialités littéraires et artistiques plurivalentes,13,0.04365639062395057,14.0
+"Finances, banque, assurances","Spécialités pluridisciplinaires, sciences humaines et droit",13,0.04365639062395057,0.0
+"Commerce, vente","Vie familiale, vie sociale et autres formations au développement personnel",13,0.04365639062395057,85.66666666666667
+"Coiffure, esthétique et autres spécialités des services aux personnes",Travail social,13,0.04365639062395057,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Spécialités pluritechnologiques, génie civil, construction, bois",13,0.04365639062395057,52.0
+Arts plastiques,"Musique, arts du spectacle",13,0.04365639062395057,17.0
+Spécialités pluriscientifiques,Spécialités plurivalentes des échanges et de la gestion,13,0.04365639062395057,149.0
+Autres...,Développement des capacités mentales et apprentissages de base,13,0.04365639062395057,80.0
+"Droit, sciences politiques","Energie, génie climatique",13,0.04365639062395057,0.0
+Spécialités plurivalentes sanitaires et sociales,"Transport, manutention, magasinage",13,0.04365639062395057,215.5
+Technologies industrielles fondamentales,Transformations chimiques et apparentées (y compris pharmaceutiques),13,0.04365639062395057,66.0
+Application des droits et statuts des personnes,Travail social,13,0.04365639062395057,0.0
+"Spécialités plutitechnologiques, mécanique-électricité","Transport, manutention, magasinage",13,0.04365639062395057,189.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes de la communication,13,0.04365639062395057,153.2
+"Comptabilité, gestion",Techniques de l'imprimerie et de l'édition,13,0.04365639062395057,146.5
+"Langues vivantes, civilisations étrangères et régionales",Spécialités concernant plusieurs capacités,12,0.04029820672980052,184.0
+"Animation culturelle, sportive et de loisirs",Spécialités plurivalentes des échanges et de la gestion,12,0.04029820672980052,0.0
+"Finances, banque, assurances","Mathématiques, statistiques",12,0.04029820672980052,0.0
+Sciences de la terre,Sciences naturelles (Biologie-Géologie),12,0.04029820672980052,0.0
+Bâtiment: construction et couverture,"Matériaux de construction, verre, céramique",12,0.04029820672980052,115.5
+Autres...,"Spécialités pluritechnologiques, génie civil, construction, bois",12,0.04029820672980052,169.0
+Autres...,Technologies de commandes des transformations industrielles,12,0.04029820672980052,54.0
+"Energie, génie climatique",Moteurs et mécanique auto,12,0.04029820672980052,352.0
+"Comptabilité, gestion","Musique, arts du spectacle",12,0.04029820672980052,48.0
+"Energie, génie climatique","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",12,0.04029820672980052,134.0
+"Enseignement, formation","Mathématiques, statistiques",12,0.04029820672980052,0.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités plurivalentes des échanges et de la gestion,12,0.04029820672980052,0.0
+"Animation culturelle, sportive et de loisirs","Secrétariat, bureautique",12,0.04029820672980052,216.0
+"Comptabilité, gestion","Productions animales, élevage spécialisé, aquaculture, ...",12,0.04029820672980052,507.0
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes de la communication,12,0.04029820672980052,193.0
+"Accueil, hôtellerie, tourisme","Coiffure, esthétique et autres spécialités des services aux personnes",12,0.04029820672980052,0.0
+Application des droits et statuts des personnes,"Sécurité des biens et des personnes, police, surveillance",12,0.04029820672980052,296.0
+"Comptabilité, gestion","Techniques de l'image et du son, métiers connexes du spectacle",12,0.04029820672980052,63.25
+Arts plastiques,Journalisme et communication,12,0.04029820672980052,0.0
+"Enseignement, formation","Productions animales, élevage spécialisé, aquaculture, ...",12,0.04029820672980052,4.0
+"Aménagement du territoire, développement, urbanisme","Informatique, traitement de l'information, réseaux de transmission des données",12,0.04029820672980052,161.5
+Economie,Linguistique,12,0.04029820672980052,532.0
+Autres...,Textile,12,0.04029820672980052,129.66666666666666
+"Coiffure, esthétique et autres spécialités des services aux personnes","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",12,0.04029820672980052,118.0
+Linguistique,Santé,12,0.04029820672980052,5946.5
+Spécialités plurivalentes sanitaires et sociales,"Vie familiale, vie sociale et autres formations au développement personnel",12,0.04029820672980052,109.0
+"Droit, sciences politiques","Spécialités pluritechnologiques, génie civil, construction, bois",12,0.04029820672980052,121.0
+"Energie, génie climatique",Spécialités pluriscientifiques,12,0.04029820672980052,0.0
+Formations générales,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",12,0.04029820672980052,268.25
+"Agro-alimentaire, alimentation, cuisine",Technologies industrielles fondamentales,12,0.04029820672980052,249.0
+Formations générales,Techniques de l'imprimerie et de l'édition,12,0.04029820672980052,110.0
+"Français, littérature et civilisation françaises",Spécialités plurivalentes des échanges et de la gestion,12,0.04029820672980052,427.0
+"Sécurité des biens et des personnes, police, surveillance","Techniques de l'image et du son, métiers connexes du spectacle",12,0.04029820672980052,820.5
+Spécialités plurivalentes des services à la collectivité,Spécialités plurivalentes sanitaires et sociales,11,0.03694002283565048,0.0
+"Aménagement du territoire, développement, urbanisme",Bâtiment: finitions,11,0.03694002283565048,0.0
+"Agro-alimentaire, alimentation, cuisine",Transformations chimiques et apparentées (y compris pharmaceutiques),11,0.03694002283565048,260.0
+"Philosophie, éthique et théologie",Santé,11,0.03694002283565048,119.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Linguistique,11,0.03694002283565048,0.0
+"Energie, génie climatique","Ressources humaines, gestion du personnel, gestion de l'emploi",11,0.03694002283565048,0.0
+Arts plastiques,"Techniques de l'image et du son, métiers connexes du spectacle",11,0.03694002283565048,0.0
+Développement des capacités mentales et apprentissages de base,"Sécurité des biens et des personnes, police, surveillance",11,0.03694002283565048,311.0
+Autres...,Spécialités pluriscientifiques,11,0.03694002283565048,39.5
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes de la communication,11,0.03694002283565048,29.0
+"Electricité, électronique (non compris automatisme et productique)","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",11,0.03694002283565048,329.0
+Application des droits et statuts des personnes,"Enseignement, formation",11,0.03694002283565048,129.0
+Arts plastiques,Autres...,11,0.03694002283565048,0.0
+Développement des capacités comportementales et relationnelles,"Techniques de l'image et du son, métiers connexes du spectacle",11,0.03694002283565048,204.0
+Pratiques sportives,"Ressources humaines, gestion du personnel, gestion de l'emploi",11,0.03694002283565048,70.0
+Développement des capacités comportementales et relationnelles,Jeux et activités spécifiques de loisirs,11,0.03694002283565048,79.5
+"Comptabilité, gestion","Français, littérature et civilisation françaises",11,0.03694002283565048,100.33333333333333
+Arts plastiques,"Langues vivantes, civilisations étrangères et régionales",11,0.03694002283565048,117.0
+"Finances, banque, assurances","Langues vivantes, civilisations étrangères et régionales",11,0.03694002283565048,31.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes des services,11,0.03694002283565048,1146.0
+Bâtiment: finitions,"Informatique, traitement de l'information, réseaux de transmission des données",11,0.03694002283565048,136.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Finances, banque, assurances",11,0.03694002283565048,3753.25
+Bâtiment: finitions,"Ressources humaines, gestion du personnel, gestion de l'emploi",11,0.03694002283565048,69.0
+Spécialités pluritechnologiques des transformations,"Spécialités plutitechnologiques, mécanique-électricité",11,0.03694002283565048,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Spécialités plutitechnologiques, mécanique-électricité",11,0.03694002283565048,0.0
+"Commerce, vente",Spécialités pluriscientifiques,11,0.03694002283565048,132.0
+"Langues vivantes, civilisations étrangères et régionales",Spécialités plurivalentes sanitaires et sociales,11,0.03694002283565048,176.75
+"Spécialités plutitechnologiques, mécanique-électricité","Sécurité des biens et des personnes, police, surveillance",11,0.03694002283565048,321.5
+Formations générales,Mécanique aéronautique et spatiale,11,0.03694002283565048,8.0
+Bâtiment: construction et couverture,"Langues vivantes, civilisations étrangères et régionales",11,0.03694002283565048,109.5
+Formations générales,Spécialités pluritechnologiques des transformations,11,0.03694002283565048,69.66666666666667
+"Finances, banque, assurances",Linguistique,11,0.03694002283565048,37.0
+"Agro-alimentaire, alimentation, cuisine","Spécialités pluritechnologiques, génie civil, construction, bois",11,0.03694002283565048,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Plasturgie, matériaux composites",10,0.033581838941500436,269.5
+Langues et civilisations anciennes,"Langues vivantes, civilisations étrangères et régionales",10,0.033581838941500436,493.0
+Cuirs et peaux,"Habillement (y compris mode, couture)",10,0.033581838941500436,96.5
+Développement des capacités individuelles d'organisation,Journalisme et communication,10,0.033581838941500436,0.0
+Développement des capacités comportementales et relationnelles,"Philosophie, éthique et théologie",10,0.033581838941500436,0.0
+"Langues vivantes, civilisations étrangères et régionales",Psychologie,10,0.033581838941500436,0.0
+"Aménagement du territoire, développement, urbanisme",Protection et développement du patrimoine,10,0.033581838941500436,40.0
+"Commerce, vente",Travail du bois et de l'ameublement,10,0.033581838941500436,1296.5
+Développement des capacités individuelles d'organisation,Pratiques sportives,10,0.033581838941500436,0.0
+Economie,Journalisme et communication,10,0.033581838941500436,0.0
+Développement des capacités comportementales et relationnelles,"Productions animales, élevage spécialisé, aquaculture, ...",10,0.033581838941500436,0.0
+"Animation culturelle, sportive et de loisirs",Développement des capacités mentales et apprentissages de base,10,0.033581838941500436,261.0
+Bâtiment: finitions,"Sécurité des biens et des personnes, police, surveillance",10,0.033581838941500436,84.0
+Spécialités plurivalentes des services,"Spécialités plutitechnologiques, mécanique-électricité",10,0.033581838941500436,474.0
+Spécialités plurivalentes des échanges et de la gestion,"Techniques de l'image et du son, métiers connexes du spectacle",10,0.033581838941500436,61.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités pluriscientifiques,10,0.033581838941500436,0.0
+"Accueil, hôtellerie, tourisme",Développement des capacités individuelles d'organisation,10,0.033581838941500436,81.0
+"Musique, arts du spectacle","Ressources humaines, gestion du personnel, gestion de l'emploi",10,0.033581838941500436,18.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Ressources humaines, gestion du personnel, gestion de l'emploi",10,0.033581838941500436,271.3333333333333
+"Animation culturelle, sportive et de loisirs","Musique, arts du spectacle",10,0.033581838941500436,149.5
+"Langues vivantes, civilisations étrangères et régionales","Mathématiques, statistiques",10,0.033581838941500436,0.0
+"Français, littérature et civilisation françaises",Journalisme et communication,10,0.033581838941500436,58.0
+"Agro-alimentaire, alimentation, cuisine","Spécialités pluridisciplinaires, sciences humaines et droit",10,0.033581838941500436,248.0
+Psychologie,Spécialités plurivalentes de la communication,10,0.033581838941500436,379.0
+"Accueil, hôtellerie, tourisme",Linguistique,10,0.033581838941500436,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Linguistique,10,0.033581838941500436,5.5
+Linguistique,"Musique, arts du spectacle",10,0.033581838941500436,17.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes de l'agronomie et de l'agriculture,10,0.033581838941500436,0.0
+Journalisme et communication,"Spécialités pluridisciplinaires, sciences humaines et droit",10,0.033581838941500436,0.0
+Formations générales,"Forêts, espaces naturels, faune sauvage, pêche",10,0.033581838941500436,101.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Autres...,10,0.033581838941500436,133.0
+"Mécanique générale et de précision, usinage","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",10,0.033581838941500436,198.5
+Structures métalliques,Technologies industrielles fondamentales,10,0.033581838941500436,104.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Sécurité des biens et des personnes, police, surveillance",10,0.033581838941500436,464.3333333333333
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes de l'agronomie et de l'agriculture,10,0.033581838941500436,181.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Techniques de l'image et du son, métiers connexes du spectacle",10,0.033581838941500436,56.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Spécialités pluridisciplinaires, sciences humaines et droit",10,0.033581838941500436,336.5
+Technologies industrielles fondamentales,"Transport, manutention, magasinage",10,0.033581838941500436,0.0
+"Energie, génie climatique","Mines et carrières, génie civil, topographie",10,0.033581838941500436,112.0
+"Nettoyage, assainissement, protection de l'environnement","Secrétariat, bureautique",10,0.033581838941500436,74.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Spécialités pluritechnologiques, génie civil, construction, bois",10,0.033581838941500436,0.0
+Linguistique,Technologies industrielles fondamentales,10,0.033581838941500436,6.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,"Transport, manutention, magasinage",10,0.033581838941500436,255.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Techniques de l'image et du son, métiers connexes du spectacle",9,0.03022365504735039,62.5
+Développement des capacités mentales et apprentissages de base,Spécialités plurivalentes de la communication,9,0.03022365504735039,77.0
+Développement des capacités mentales et apprentissages de base,Spécialités plurivalentes sanitaires et sociales,9,0.03022365504735039,329.3333333333333
+"Aménagement du territoire, développement, urbanisme","Commerce, vente",9,0.03022365504735039,0.0
+Développement des capacités comportementales et relationnelles,"Energie, génie climatique",9,0.03022365504735039,88.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Technologies de commandes des transformations industrielles,9,0.03022365504735039,13.0
+"Enseignement, formation",Jeux et activités spécifiques de loisirs,9,0.03022365504735039,67.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Ressources humaines, gestion du personnel, gestion de l'emploi",9,0.03022365504735039,30.0
+Application des droits et statuts des personnes,"Droit, sciences politiques",9,0.03022365504735039,0.0
+Application des droits et statuts des personnes,"Informatique, traitement de l'information, réseaux de transmission des données",9,0.03022365504735039,0.0
+"Comptabilité, gestion","Sciences sociales (y compris démographie, anthropologie)",9,0.03022365504735039,0.0
+Formations générales,Sciences de la vie,9,0.03022365504735039,55.5
+Arts plastiques,"Commerce, vente",9,0.03022365504735039,108.0
+Spécialités pluritechnologiques des transformations,"Spécialités pluritechnologiques, génie civil, construction, bois",9,0.03022365504735039,0.0
+Spécialités plurivalentes des échanges et de la gestion,Travail social,9,0.03022365504735039,49.0
+Journalisme et communication,Santé,9,0.03022365504735039,120.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Habillement (y compris mode, couture)",9,0.03022365504735039,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Sécurité des biens et des personnes, police, surveillance",9,0.03022365504735039,464.0
+Arts plastiques,"Français, littérature et civilisation françaises",9,0.03022365504735039,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Vie familiale, vie sociale et autres formations au développement personnel",9,0.03022365504735039,7.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Santé,9,0.03022365504735039,55.0
+Linguistique,Spécialités littéraires et artistiques plurivalentes,9,0.03022365504735039,0.0
+"Français, littérature et civilisation françaises",Spécialités plurivalentes sanitaires et sociales,9,0.03022365504735039,223.0
+"Animation culturelle, sportive et de loisirs","Langues vivantes, civilisations étrangères et régionales",9,0.03022365504735039,132.0
+Economie,"Français, littérature et civilisation françaises",9,0.03022365504735039,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Informatique, traitement de l'information, réseaux de transmission des données",9,0.03022365504735039,235.0
+"Philosophie, éthique et théologie",Psychologie,9,0.03022365504735039,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Langues vivantes, civilisations étrangères et régionales",9,0.03022365504735039,19.0
+"Habillement (y compris mode, couture)",Spécialités plurivalentes des échanges et de la gestion,9,0.03022365504735039,0.0
+"Comptabilité, gestion",Technologies de commandes des transformations industrielles,9,0.03022365504735039,76.0
+Autres...,"Spécialités plutitechnologiques, mécanique-électricité",9,0.03022365504735039,0.0
+Formations générales,Physique,9,0.03022365504735039,0.0
+Spécialités pluriscientifiques,"Spécialités pluritechnologiques, génie civil, construction, bois",9,0.03022365504735039,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes de l'agronomie et de l'agriculture,9,0.03022365504735039,0.0
+"Plasturgie, matériaux composites","Ressources humaines, gestion du personnel, gestion de l'emploi",9,0.03022365504735039,159.66666666666666
+Développement des capacités individuelles d'organisation,"Nettoyage, assainissement, protection de l'environnement",9,0.03022365504735039,86.0
+Bâtiment: finitions,"Secrétariat, bureautique",9,0.03022365504735039,136.33333333333334
+"Mines et carrières, génie civil, topographie","Sécurité des biens et des personnes, police, surveillance",9,0.03022365504735039,0.0
+"Agro-alimentaire, alimentation, cuisine","Animation culturelle, sportive et de loisirs",9,0.03022365504735039,159.5
+Bâtiment: construction et couverture,Linguistique,9,0.03022365504735039,106.5
+"Electricité, électronique (non compris automatisme et productique)",Mécanique aéronautique et spatiale,9,0.03022365504735039,0.0
+Formations générales,"Matériaux de construction, verre, céramique",9,0.03022365504735039,256.5
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes de l'agronomie et de l'agriculture,9,0.03022365504735039,320.0
+Spécialités plurivalentes de la communication,Travail social,9,0.03022365504735039,214.66666666666666
+Formations générales,"Philosophie, éthique et théologie",9,0.03022365504735039,152.5
+"Droit, sciences politiques","Electricité, électronique (non compris automatisme et productique)",9,0.03022365504735039,0.0
+"Agro-alimentaire, alimentation, cuisine","Forêts, espaces naturels, faune sauvage, pêche",9,0.03022365504735039,122.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Spécialités plutitechnologiques, mécanique-électricité",9,0.03022365504735039,0.0
+"Langues vivantes, civilisations étrangères et régionales","Productions végétales,cultures spécialisées",9,0.03022365504735039,64.0
+"Agro-alimentaire, alimentation, cuisine",Structures métalliques,9,0.03022365504735039,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Spécialités plutitechnologiques, mécanique-électricité",8,0.02686547115320035,29.0
+Santé,"Techniques de l'image et du son, métiers connexes du spectacle",8,0.02686547115320035,0.0
+Spécialités plurivalentes de la communication,Spécialités plurivalentes des services à la collectivité,8,0.02686547115320035,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes des services,8,0.02686547115320035,0.0
+"Secrétariat, bureautique","Spécialités pluritechnologiques, génie civil, construction, bois",8,0.02686547115320035,29.0
+"Agro-alimentaire, alimentation, cuisine","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",8,0.02686547115320035,96.0
+Mécanique aéronautique et spatiale,Structures métalliques,8,0.02686547115320035,104.0
+Spécialités plurivalentes de la communication,"Vie familiale, vie sociale et autres formations au développement personnel",8,0.02686547115320035,26.0
+"Philosophie, éthique et théologie","Sciences sociales (y compris démographie, anthropologie)",8,0.02686547115320035,0.0
+Linguistique,"Nettoyage, assainissement, protection de l'environnement",8,0.02686547115320035,195.0
+Autres...,Travail du bois et de l'ameublement,8,0.02686547115320035,25.0
+"Commerce, vente","Musique, arts du spectacle",8,0.02686547115320035,26.5
+"Enseignement, formation",Moteurs et mécanique auto,8,0.02686547115320035,683.0
+Autres...,Jeux et activités spécifiques de loisirs,8,0.02686547115320035,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités plurivalentes sanitaires et sociales,8,0.02686547115320035,169.5
+Autres...,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",8,0.02686547115320035,0.0
+Mécanique aéronautique et spatiale,Technologies industrielles fondamentales,8,0.02686547115320035,104.0
+Journalisme et communication,"Vie familiale, vie sociale et autres formations au développement personnel",8,0.02686547115320035,0.0
+Economie,"Secrétariat, bureautique",8,0.02686547115320035,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Animation culturelle, sportive et de loisirs",8,0.02686547115320035,123.0
+"Droit, sciences politiques","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",8,0.02686547115320035,98.0
+"Animation culturelle, sportive et de loisirs",Journalisme et communication,8,0.02686547115320035,0.0
+"Commerce, vente","Documentation, bibliothèques, administration des données",8,0.02686547115320035,0.0
+"Agro-alimentaire, alimentation, cuisine",Textile,8,0.02686547115320035,775.6666666666666
+"Comptabilité, gestion",Psychologie,8,0.02686547115320035,0.0
+"Documentation, bibliothèques, administration des données","Ressources humaines, gestion du personnel, gestion de l'emploi",8,0.02686547115320035,388.0
+"Agro-alimentaire, alimentation, cuisine",Journalisme et communication,8,0.02686547115320035,27.5
+"Habillement (y compris mode, couture)",Spécialités plurivalentes de la communication,8,0.02686547115320035,0.0
+Arts plastiques,Spécialités plurivalentes de la communication,8,0.02686547115320035,117.0
+Economie,Santé,8,0.02686547115320035,0.0
+Journalisme et communication,Spécialités plurivalentes des services,8,0.02686547115320035,0.0
+"Mathématiques, statistiques","Secrétariat, bureautique",8,0.02686547115320035,0.0
+"Enseignement, formation","Spécialités pluritechnologiques, génie civil, construction, bois",8,0.02686547115320035,653.0
+"Animation culturelle, sportive et de loisirs","Productions animales, élevage spécialisé, aquaculture, ...",8,0.02686547115320035,0.0
+"Aménagement du territoire, développement, urbanisme","Nettoyage, assainissement, protection de l'environnement",8,0.02686547115320035,540.0
+"Langues vivantes, civilisations étrangères et régionales",Techniques de l'imprimerie et de l'édition,8,0.02686547115320035,86.0
+Economie,Spécialités plurivalentes des services,8,0.02686547115320035,107.5
+"Commerce, vente",Langues et civilisations anciennes,8,0.02686547115320035,26.0
+Spécialités pluriscientifiques,Spécialités plurivalentes de la communication,8,0.02686547115320035,84.5
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Français, littérature et civilisation françaises",8,0.02686547115320035,548.0
+Santé,Spécialités concernant plusieurs capacités,8,0.02686547115320035,206.0
+Sciences naturelles (Biologie-Géologie),Spécialités pluriscientifiques,8,0.02686547115320035,49.0
+"Enseignement, formation",Spécialités pluriscientifiques,8,0.02686547115320035,354.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités pluriscientifiques,8,0.02686547115320035,0.0
+Psychologie,"Sécurité des biens et des personnes, police, surveillance",8,0.02686547115320035,188.33333333333334
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Transport, manutention, magasinage",8,0.02686547115320035,311.0
+"Langues vivantes, civilisations étrangères et régionales","Sciences sociales (y compris démographie, anthropologie)",8,0.02686547115320035,0.0
+Autres...,"Mécanique générale et de précision, usinage",8,0.02686547115320035,73.0
+Bâtiment: construction et couverture,Spécialités plurivalentes des services,8,0.02686547115320035,31.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Enseignement, formation",8,0.02686547115320035,63.0
+Spécialités pluriscientifiques,"Spécialités plutitechnologiques, mécanique-électricité",8,0.02686547115320035,0.0
+Spécialités plurivalentes des services à la collectivité,"Sécurité des biens et des personnes, police, surveillance",8,0.02686547115320035,76.0
+"Français, littérature et civilisation françaises","Spécialités pluridisciplinaires, sciences humaines et droit",8,0.02686547115320035,19.0
+"Langues vivantes, civilisations étrangères et régionales",Travail social,8,0.02686547115320035,74.5
+"Energie, génie climatique","Mécanique générale et de précision, usinage",8,0.02686547115320035,273.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes des échanges et de la gestion,8,0.02686547115320035,0.0
+Développement des capacités individuelles d'organisation,Linguistique,8,0.02686547115320035,70.0
+"Nettoyage, assainissement, protection de l'environnement",Travail social,8,0.02686547115320035,60.0
+"Mécanique générale et de précision, usinage","Transport, manutention, magasinage",8,0.02686547115320035,0.0
+"Agro-alimentaire, alimentation, cuisine","Techniques de l'image et du son, métiers connexes du spectacle",8,0.02686547115320035,57.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Ressources humaines, gestion du personnel, gestion de l'emploi",8,0.02686547115320035,0.0
+"Energie, génie climatique",Structures métalliques,8,0.02686547115320035,53.0
+"Comptabilité, gestion",Technologies industrielles fondamentales,8,0.02686547115320035,236.66666666666666
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Spécialités pluritechnologiques, génie civil, construction, bois",8,0.02686547115320035,66.0
+Formations générales,Structures métalliques,8,0.02686547115320035,110.0
+Bâtiment: finitions,Technologies industrielles fondamentales,8,0.02686547115320035,197.5
+"Aménagement paysager (parcs, jardins, espaces verts)",Linguistique,8,0.02686547115320035,118.5
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes des services,8,0.02686547115320035,419.6666666666667
+"Productions végétales,cultures spécialisées","Transport, manutention, magasinage",8,0.02686547115320035,0.0
+"Droit, sciences politiques",Spécialités plurivalentes de l'agronomie et de l'agriculture,8,0.02686547115320035,0.0
+"Langues vivantes, civilisations étrangères et régionales",Technologies de commandes des transformations industrielles,8,0.02686547115320035,0.0
+Développement des capacités comportementales et relationnelles,"Electricité, électronique (non compris automatisme et productique)",7,0.023507287259050304,207.5
+Bâtiment: construction et couverture,"Nettoyage, assainissement, protection de l'environnement",7,0.023507287259050304,72.33333333333333
+Bâtiment: construction et couverture,Santé,7,0.023507287259050304,92.0
+"Energie, génie climatique","Productions végétales,cultures spécialisées",7,0.023507287259050304,366.0
+Cuirs et peaux,Textile,7,0.023507287259050304,23.0
+"Agro-alimentaire, alimentation, cuisine","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",7,0.023507287259050304,134.0
+"Commerce, vente","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",7,0.023507287259050304,68.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Développement des capacités mentales et apprentissages de base,7,0.023507287259050304,0.0
+"Documentation, bibliothèques, administration des données",Spécialités plurivalentes de la communication,7,0.023507287259050304,27.0
+"Droit, sciences politiques","Nettoyage, assainissement, protection de l'environnement",7,0.023507287259050304,75.0
+Bâtiment: finitions,"Matériaux de construction, verre, céramique",7,0.023507287259050304,372.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Musique, arts du spectacle",7,0.023507287259050304,157.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités plurivalentes des échanges et de la gestion,7,0.023507287259050304,228.0
+"Documentation, bibliothèques, administration des données",Journalisme et communication,7,0.023507287259050304,0.0
+"Droit, sciences politiques",Histoire,7,0.023507287259050304,0.0
+Histoire,"Philosophie, éthique et théologie",7,0.023507287259050304,0.0
+"Animation culturelle, sportive et de loisirs",Arts plastiques,7,0.023507287259050304,0.0
+Arts plastiques,"Matériaux de construction, verre, céramique",7,0.023507287259050304,0.0
+"Enseignement, formation",Sciences de la vie,7,0.023507287259050304,0.0
+"Nettoyage, assainissement, protection de l'environnement",Sciences de la terre,7,0.023507287259050304,0.0
+"Energie, génie climatique",Sciences de la terre,7,0.023507287259050304,0.0
+Sciences de la terre,"Sciences sociales (y compris démographie, anthropologie)",7,0.023507287259050304,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Comptabilité, gestion",7,0.023507287259050304,10.0
+"Enseignement, formation",Technologies industrielles fondamentales,7,0.023507287259050304,48.0
+Mécanique aéronautique et spatiale,"Spécialités plutitechnologiques, mécanique-électricité",7,0.023507287259050304,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités concernant plusieurs capacités,7,0.023507287259050304,57.0
+"Langues vivantes, civilisations étrangères et régionales",Pratiques sportives,7,0.023507287259050304,18.0
+"Droit, sciences politiques","Transport, manutention, magasinage",7,0.023507287259050304,0.0
+"Droit, sciences politiques","Musique, arts du spectacle",7,0.023507287259050304,134.0
+Géographie,"Informatique, traitement de l'information, réseaux de transmission des données",7,0.023507287259050304,0.0
+Autres...,Moteurs et mécanique auto,7,0.023507287259050304,1174.0
+Mécanique aéronautique et spatiale,"Transport, manutention, magasinage",7,0.023507287259050304,0.0
+"Aménagement du territoire, développement, urbanisme","Finances, banque, assurances",7,0.023507287259050304,0.0
+"Français, littérature et civilisation françaises","Musique, arts du spectacle",7,0.023507287259050304,548.0
+"Langues vivantes, civilisations étrangères et régionales","Musique, arts du spectacle",7,0.023507287259050304,37.0
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes des services à la collectivité,7,0.023507287259050304,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités pluriscientifiques,7,0.023507287259050304,65.0
+"Animation culturelle, sportive et de loisirs","Nettoyage, assainissement, protection de l'environnement",7,0.023507287259050304,200.0
+"Chimie-biologie, biochimie",Sciences naturelles (Biologie-Géologie),7,0.023507287259050304,0.0
+Pratiques sportives,"Transport, manutention, magasinage",7,0.023507287259050304,0.0
+Economie,"Energie, génie climatique",7,0.023507287259050304,0.0
+Développement des capacités individuelles d'organisation,"Langues vivantes, civilisations étrangères et régionales",7,0.023507287259050304,0.0
+"Chimie-biologie, biochimie",Physique-chimie,7,0.023507287259050304,0.0
+"Mathématiques, statistiques",Sciences naturelles (Biologie-Géologie),7,0.023507287259050304,49.0
+"Droit, sciences politiques",Spécialités plurivalentes des services,7,0.023507287259050304,83.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes de la communication,7,0.023507287259050304,24.0
+Développement des capacités mentales et apprentissages de base,Journalisme et communication,7,0.023507287259050304,0.0
+Autres...,"Habillement (y compris mode, couture)",7,0.023507287259050304,0.0
+Mécanique aéronautique et spatiale,"Mécanique générale et de précision, usinage",7,0.023507287259050304,156.0
+"Animation culturelle, sportive et de loisirs","Comptabilité, gestion",7,0.023507287259050304,81.5
+Economie,Histoire,7,0.023507287259050304,0.0
+"Droit, sciences politiques",Spécialités concernant plusieurs capacités,7,0.023507287259050304,569.5
+Développement des capacités individuelles d'organisation,Spécialités plurivalentes sanitaires et sociales,7,0.023507287259050304,478.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Travail social,7,0.023507287259050304,355.5
+"Electricité, électronique (non compris automatisme et productique)","Techniques de l'image et du son, métiers connexes du spectacle",7,0.023507287259050304,296.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Textile,7,0.023507287259050304,64.0
+"Chimie-biologie, biochimie","Mathématiques, statistiques",7,0.023507287259050304,0.0
+Santé,Sciences naturelles (Biologie-Géologie),7,0.023507287259050304,0.0
+Développement des capacités individuelles d'organisation,Psychologie,7,0.023507287259050304,0.0
+"Aménagement du territoire, développement, urbanisme","Spécialités pluritechnologiques, génie civil, construction, bois",7,0.023507287259050304,0.0
+"Secrétariat, bureautique","Spécialités pluridisciplinaires, sciences humaines et droit",7,0.023507287259050304,98.0
+Linguistique,Psychologie,7,0.023507287259050304,0.0
+Textile,Travail du bois et de l'ameublement,7,0.023507287259050304,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Technologies industrielles fondamentales,7,0.023507287259050304,0.0
+Pratiques sportives,Sciences de la vie,7,0.023507287259050304,0.0
+"Aménagement du territoire, développement, urbanisme","Forêts, espaces naturels, faune sauvage, pêche",7,0.023507287259050304,136.0
+Psychologie,Spécialités concernant plusieurs capacités,7,0.023507287259050304,445.0
+Linguistique,Spécialités plurivalentes des services,7,0.023507287259050304,187.0
+"Animation culturelle, sportive et de loisirs","Transport, manutention, magasinage",7,0.023507287259050304,0.0
+Pratiques sportives,"Productions animales, élevage spécialisé, aquaculture, ...",7,0.023507287259050304,124.5
+Application des droits et statuts des personnes,Santé,7,0.023507287259050304,1715.0
+Bâtiment: finitions,"Enseignement, formation",7,0.023507287259050304,0.0
+"Documentation, bibliothèques, administration des données","Enseignement, formation",7,0.023507287259050304,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités concernant plusieurs capacités,7,0.023507287259050304,691.0
+"Enseignement, formation",Spécialités plurivalentes de l'agronomie et de l'agriculture,7,0.023507287259050304,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Pratiques sportives,7,0.023507287259050304,39.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Moteurs et mécanique auto,7,0.023507287259050304,1344.0
+Formations générales,Sciences naturelles (Biologie-Géologie),7,0.023507287259050304,0.0
+"Commerce, vente",Transformations chimiques et apparentées (y compris pharmaceutiques),7,0.023507287259050304,85.0
+Formations générales,Spécialités plurivalentes des services à la collectivité,7,0.023507287259050304,94.0
+"Comptabilité, gestion",Pratiques sportives,7,0.023507287259050304,0.0
+"Electricité, électronique (non compris automatisme et productique)","Nettoyage, assainissement, protection de l'environnement",7,0.023507287259050304,473.0
+"Commerce, vente",Spécialités pluritechnologiques des transformations,7,0.023507287259050304,118.0
+Formations générales,Transformations chimiques et apparentées (y compris pharmaceutiques),7,0.023507287259050304,424.0
+"Animation culturelle, sportive et de loisirs","Forêts, espaces naturels, faune sauvage, pêche",7,0.023507287259050304,67.0
+"Finances, banque, assurances",Santé,7,0.023507287259050304,1113.0
+Développement des capacités comportementales et relationnelles,Spécialités pluriscientifiques,7,0.023507287259050304,0.0
+"Secrétariat, bureautique","Vie familiale, vie sociale et autres formations au développement personnel",7,0.023507287259050304,0.0
+"Langues vivantes, civilisations étrangères et régionales","Spécialités plutitechnologiques, mécanique-électricité",7,0.023507287259050304,120.0
+"Commerce, vente","Plasturgie, matériaux composites",7,0.023507287259050304,185.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",7,0.023507287259050304,43.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Travail social,7,0.023507287259050304,114.0
+"Comptabilité, gestion","Forêts, espaces naturels, faune sauvage, pêche",7,0.023507287259050304,126.33333333333333
+Linguistique,"Spécialités pluritechnologiques, génie civil, construction, bois",7,0.023507287259050304,223.5
+"Finances, banque, assurances",Technologies industrielles fondamentales,7,0.023507287259050304,90.5
+Moteurs et mécanique auto,"Ressources humaines, gestion du personnel, gestion de l'emploi",7,0.023507287259050304,683.0
+Bâtiment: construction et couverture,Technologies industrielles fondamentales,7,0.023507287259050304,0.0
+"Agro-alimentaire, alimentation, cuisine","Mécanique générale et de précision, usinage",7,0.023507287259050304,250.0
+"Forêts, espaces naturels, faune sauvage, pêche",Spécialités plurivalentes sanitaires et sociales,7,0.023507287259050304,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités plurivalentes des échanges et de la gestion,7,0.023507287259050304,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Technologies industrielles fondamentales,7,0.023507287259050304,0.0
+"Aménagement du territoire, développement, urbanisme","Enseignement, formation",6,0.02014910336490026,0.0
+Bâtiment: construction et couverture,"Productions végétales,cultures spécialisées",6,0.02014910336490026,217.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Transport, manutention, magasinage",6,0.02014910336490026,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Journalisme et communication,6,0.02014910336490026,0.0
+Spécialités plurivalentes de la communication,"Transport, manutention, magasinage",6,0.02014910336490026,183.0
+"Philosophie, éthique et théologie",Travail social,6,0.02014910336490026,0.0
+Journalisme et communication,Travail social,6,0.02014910336490026,97.0
+Moteurs et mécanique auto,"Mécanique générale et de précision, usinage",6,0.02014910336490026,0.0
+"Aménagement du territoire, développement, urbanisme","Sécurité des biens et des personnes, police, surveillance",6,0.02014910336490026,338.0
+"Philosophie, éthique et théologie",Pratiques sportives,6,0.02014910336490026,50.0
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes des services,6,0.02014910336490026,0.0
+Technologies de commandes des transformations industrielles,"Transport, manutention, magasinage",6,0.02014910336490026,0.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes des services à la collectivité,6,0.02014910336490026,0.0
+"Energie, génie climatique",Spécialités pluritechnologiques des transformations,6,0.02014910336490026,240.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités pluritechnologiques des transformations,6,0.02014910336490026,104.0
+"Mathématiques, statistiques",Sciences de la vie,6,0.02014910336490026,0.0
+Spécialités pluritechnologiques des transformations,Spécialités plurivalentes de l'agronomie et de l'agriculture,6,0.02014910336490026,0.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités plurivalentes sanitaires et sociales,6,0.02014910336490026,0.0
+"Spécialités pluritechnologiques, matériaux souples",Textile,6,0.02014910336490026,0.0
+Développement des capacités mentales et apprentissages de base,Jeux et activités spécifiques de loisirs,6,0.02014910336490026,0.0
+"Mathématiques, statistiques",Technologies industrielles fondamentales,6,0.02014910336490026,22.0
+"Comptabilité, gestion",Développement des capacités mentales et apprentissages de base,6,0.02014910336490026,188.0
+Bâtiment: construction et couverture,Développement des capacités comportementales et relationnelles,6,0.02014910336490026,81.0
+"Aménagement du territoire, développement, urbanisme","Comptabilité, gestion",6,0.02014910336490026,0.0
+"Aménagement du territoire, développement, urbanisme","Aménagement paysager (parcs, jardins, espaces verts)",6,0.02014910336490026,0.0
+Bâtiment: finitions,Spécialités plurivalentes des échanges et de la gestion,6,0.02014910336490026,213.0
+"Français, littérature et civilisation françaises",Langues et civilisations anciennes,6,0.02014910336490026,0.0
+"Plasturgie, matériaux composites",Technologies de commandes des transformations industrielles,6,0.02014910336490026,151.5
+"Informatique, traitement de l'information, réseaux de transmission des données",Psychologie,6,0.02014910336490026,0.0
+"Energie, génie climatique","Matériaux de construction, verre, céramique",6,0.02014910336490026,124.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",6,0.02014910336490026,1029.0
+Journalisme et communication,Psychologie,6,0.02014910336490026,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Psychologie,6,0.02014910336490026,0.0
+"Animation culturelle, sportive et de loisirs","Techniques de l'image et du son, métiers connexes du spectacle",6,0.02014910336490026,21.0
+"Chimie-biologie, biochimie","Commerce, vente",6,0.02014910336490026,97.0
+Chimie,"Energie, génie climatique",6,0.02014910336490026,2674.0
+Economie,"Transport, manutention, magasinage",6,0.02014910336490026,0.0
+"Commerce, vente",Spécialités plurivalentes des services à la collectivité,6,0.02014910336490026,0.0
+Economie,Sciences de la terre,6,0.02014910336490026,0.0
+Spécialités pluriscientifiques,Spécialités plurivalentes de l'agronomie et de l'agriculture,6,0.02014910336490026,0.0
+"Animation culturelle, sportive et de loisirs","Vie familiale, vie sociale et autres formations au développement personnel",6,0.02014910336490026,0.0
+Economie,Spécialités plurivalentes de la communication,6,0.02014910336490026,64.0
+Chimie,"Chimie-biologie, biochimie",6,0.02014910336490026,0.0
+"Français, littérature et civilisation françaises","Philosophie, éthique et théologie",6,0.02014910336490026,0.0
+Arts plastiques,Spécialités littéraires et artistiques plurivalentes,6,0.02014910336490026,0.0
+"Français, littérature et civilisation françaises",Santé,6,0.02014910336490026,0.0
+Développement des capacités comportementales et relationnelles,"Productions végétales,cultures spécialisées",6,0.02014910336490026,376.0
+"Productions végétales,cultures spécialisées",Sciences naturelles (Biologie-Géologie),6,0.02014910336490026,97.0
+Spécialités plurivalentes des services,Travail social,6,0.02014910336490026,88.0
+Physique,Spécialités pluriscientifiques,6,0.02014910336490026,0.0
+Spécialités pluritechnologiques des transformations,Spécialités plurivalentes des échanges et de la gestion,6,0.02014910336490026,21.0
+"Agro-alimentaire, alimentation, cuisine",Psychologie,6,0.02014910336490026,165.0
+Histoire,"Mathématiques, statistiques",6,0.02014910336490026,0.0
+Développement des capacités comportementales et relationnelles,Spécialités littéraires et artistiques plurivalentes,6,0.02014910336490026,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Coiffure, esthétique et autres spécialités des services aux personnes",6,0.02014910336490026,145.0
+Arts plastiques,Travail du bois et de l'ameublement,6,0.02014910336490026,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",6,0.02014910336490026,70.0
+"Enseignement, formation","Philosophie, éthique et théologie",6,0.02014910336490026,0.0
+"Electricité, électronique (non compris automatisme et productique)",Physique-chimie,6,0.02014910336490026,0.0
+Spécialités pluriscientifiques,Spécialités plurivalentes sanitaires et sociales,6,0.02014910336490026,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Sciences de la terre,6,0.02014910336490026,0.0
+Economie,Psychologie,6,0.02014910336490026,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Transport, manutention, magasinage",6,0.02014910336490026,0.0
+Bâtiment: finitions,Santé,6,0.02014910336490026,101.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Jeux et activités spécifiques de loisirs,6,0.02014910336490026,0.0
+Autres...,"Documentation, bibliothèques, administration des données",6,0.02014910336490026,0.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités concernant plusieurs capacités,6,0.02014910336490026,0.0
+Arts plastiques,Bâtiment: finitions,6,0.02014910336490026,23.0
+Développement des capacités comportementales et relationnelles,Technologies de commandes des transformations industrielles,6,0.02014910336490026,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités plurivalentes de la communication,6,0.02014910336490026,649.5
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Structures métalliques,6,0.02014910336490026,178.5
+Bâtiment: construction et couverture,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",6,0.02014910336490026,319.0
+Autres...,"Chimie-biologie, biochimie",6,0.02014910336490026,35.333333333333336
+"Commerce, vente","Matériaux de construction, verre, céramique",6,0.02014910336490026,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes des services,6,0.02014910336490026,0.0
+Spécialités plurivalentes de la communication,Technologies industrielles fondamentales,6,0.02014910336490026,729.0
+"Français, littérature et civilisation françaises","Sécurité des biens et des personnes, police, surveillance",6,0.02014910336490026,1307.0
+Spécialités plurivalentes des échanges et de la gestion,Technologies de commandes des transformations industrielles,6,0.02014910336490026,0.0
+"Nettoyage, assainissement, protection de l'environnement",Textile,6,0.02014910336490026,154.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes de l'agronomie et de l'agriculture,6,0.02014910336490026,464.0
+Chimie,"Electricité, électronique (non compris automatisme et productique)",6,0.02014910336490026,1301.6666666666667
+Application des droits et statuts des personnes,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",6,0.02014910336490026,327.5
+Moteurs et mécanique auto,Spécialités plurivalentes des échanges et de la gestion,6,0.02014910336490026,0.0
+Développement des capacités comportementales et relationnelles,"Spécialités pluritechnologiques, génie civil, construction, bois",6,0.02014910336490026,61.5
+"Langues vivantes, civilisations étrangères et régionales",Spécialités pluriscientifiques,6,0.02014910336490026,0.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes de la communication,6,0.02014910336490026,174.5
+"Spécialités pluridisciplinaires, sciences humaines et droit","Spécialités pluritechnologiques, génie civil, construction, bois",6,0.02014910336490026,464.0
+"Energie, génie climatique",Spécialités plurivalentes de l'agronomie et de l'agriculture,6,0.02014910336490026,157.0
+"Commerce, vente","Forêts, espaces naturels, faune sauvage, pêche",6,0.02014910336490026,0.0
+"Secrétariat, bureautique",Spécialités concernant plusieurs capacités,6,0.02014910336490026,219.0
+"Forêts, espaces naturels, faune sauvage, pêche","Sécurité des biens et des personnes, police, surveillance",6,0.02014910336490026,136.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Travail du bois et de l'ameublement,6,0.02014910336490026,140.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Mécanique aéronautique et spatiale,6,0.02014910336490026,20.0
+Bâtiment: construction et couverture,Technologies de commandes des transformations industrielles,6,0.02014910336490026,0.0
+"Nettoyage, assainissement, protection de l'environnement","Productions végétales,cultures spécialisées",6,0.02014910336490026,996.5
+"Aménagement paysager (parcs, jardins, espaces verts)","Transport, manutention, magasinage",6,0.02014910336490026,429.75
+"Productions végétales,cultures spécialisées",Spécialités plurivalentes sanitaires et sociales,6,0.02014910336490026,142.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes sanitaires et sociales,6,0.02014910336490026,426.0
+"Productions végétales,cultures spécialisées","Spécialités pluridisciplinaires, sciences humaines et droit",6,0.02014910336490026,248.0
+Structures métalliques,"Transport, manutention, magasinage",6,0.02014910336490026,429.5
+"Agro-alimentaire, alimentation, cuisine","Habillement (y compris mode, couture)",6,0.02014910336490026,77.0
+"Finances, banque, assurances","Spécialités pluritechnologiques, génie civil, construction, bois",6,0.02014910336490026,42.0
+"Français, littérature et civilisation françaises",Technologies industrielles fondamentales,6,0.02014910336490026,0.0
+Bâtiment: finitions,Spécialités plurivalentes de la communication,6,0.02014910336490026,30.0
+Bâtiment: construction et couverture,Spécialités plurivalentes des échanges et de la gestion,6,0.02014910336490026,49.0
+"Langues vivantes, civilisations étrangères et régionales",Moteurs et mécanique auto,6,0.02014910336490026,0.0
+Spécialités pluriscientifiques,Technologies de commandes des transformations industrielles,6,0.02014910336490026,0.0
+Bâtiment: construction et couverture,Spécialités plurivalentes sanitaires et sociales,6,0.02014910336490026,0.0
+Moteurs et mécanique auto,Spécialités plurivalentes de l'agronomie et de l'agriculture,6,0.02014910336490026,0.0
+"Plasturgie, matériaux composites","Spécialités plutitechnologiques, mécanique-électricité",5,0.016790919470750218,127.0
+"Documentation, bibliothèques, administration des données","Techniques de l'image et du son, métiers connexes du spectacle",5,0.016790919470750218,0.0
+Spécialités plurivalentes des services,"Techniques de l'image et du son, métiers connexes du spectacle",5,0.016790919470750218,69.0
+Autres...,Spécialités militaires,5,0.016790919470750218,0.0
+Autres...,"Mines et carrières, génie civil, topographie",5,0.016790919470750218,0.0
+"Sécurité des biens et des personnes, police, surveillance",Technologies de commandes des transformations industrielles,5,0.016790919470750218,60.0
+Pratiques sportives,Sciences naturelles (Biologie-Géologie),5,0.016790919470750218,0.0
+Autres...,Spécialités plurivalentes des services à la collectivité,5,0.016790919470750218,0.0
+"Energie, génie climatique","Productions animales, élevage spécialisé, aquaculture, ...",5,0.016790919470750218,0.0
+"Secrétariat, bureautique",Technologies industrielles fondamentales,5,0.016790919470750218,6.0
+"Energie, génie climatique",Santé,5,0.016790919470750218,41.0
+"Enseignement, formation","Mécanique générale et de précision, usinage",5,0.016790919470750218,0.0
+"Agro-alimentaire, alimentation, cuisine",Technologies de commandes des transformations industrielles,5,0.016790919470750218,0.0
+Physique,Physique-chimie,5,0.016790919470750218,0.0
+"Enseignement, formation",Structures métalliques,5,0.016790919470750218,164.0
+Développement des capacités mentales et apprentissages de base,"Musique, arts du spectacle",5,0.016790919470750218,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Transport, manutention, magasinage",5,0.016790919470750218,18.0
+"Commerce, vente",Sciences de la vie,5,0.016790919470750218,156.0
+Bâtiment: finitions,Technologies de commandes des transformations industrielles,5,0.016790919470750218,34.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Nettoyage, assainissement, protection de l'environnement",5,0.016790919470750218,241.0
+Spécialités pluriscientifiques,Spécialités pluritechnologiques des transformations,5,0.016790919470750218,0.0
+Physique-chimie,Sciences de la terre,5,0.016790919470750218,0.0
+"Droit, sciences politiques","Mathématiques, statistiques",5,0.016790919470750218,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Sécurité des biens et des personnes, police, surveillance",5,0.016790919470750218,107.0
+Arts plastiques,Travail social,5,0.016790919470750218,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités concernant plusieurs capacités,5,0.016790919470750218,54.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Développement des capacités individuelles d'organisation,5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Langues et civilisations anciennes,5,0.016790919470750218,36.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Santé,5,0.016790919470750218,0.0
+Autres...,Protection et développement du patrimoine,5,0.016790919470750218,102.0
+"Enseignement, formation",Sciences de la terre,5,0.016790919470750218,0.0
+Cuirs et peaux,Formations générales,5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Structures métalliques,5,0.016790919470750218,251.0
+Journalisme et communication,"Sciences sociales (y compris démographie, anthropologie)",5,0.016790919470750218,186.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités pluritechnologiques des transformations,5,0.016790919470750218,0.0
+Sciences de la vie,"Sciences sociales (y compris démographie, anthropologie)",5,0.016790919470750218,0.0
+Arts plastiques,Psychologie,5,0.016790919470750218,0.0
+"Commerce, vente",Protection et développement du patrimoine,5,0.016790919470750218,13.0
+"Comptabilité, gestion",Protection et développement du patrimoine,5,0.016790919470750218,0.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités plurivalentes des services,5,0.016790919470750218,0.0
+"Enseignement, formation",Spécialités littéraires et artistiques plurivalentes,5,0.016790919470750218,0.0
+"Musique, arts du spectacle",Santé,5,0.016790919470750218,126.0
+Psychologie,Sciences de la vie,5,0.016790919470750218,0.0
+Arts plastiques,"Enseignement, formation",5,0.016790919470750218,3.0
+Linguistique,"Techniques de l'image et du son, métiers connexes du spectacle",5,0.016790919470750218,0.0
+Application des droits et statuts des personnes,Formations générales,5,0.016790919470750218,0.0
+"Aménagement du territoire, développement, urbanisme",Economie,5,0.016790919470750218,112.0
+Chimie,"Mathématiques, statistiques",5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Plasturgie, matériaux composites",5,0.016790919470750218,289.0
+"Droit, sciences politiques",Spécialités pluriscientifiques,5,0.016790919470750218,0.0
+"Habillement (y compris mode, couture)","Spécialités pluritechnologiques, matériaux souples",5,0.016790919470750218,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Spécialités pluritechnologiques, génie civil, construction, bois",5,0.016790919470750218,0.0
+"Aménagement du territoire, développement, urbanisme","Energie, génie climatique",5,0.016790919470750218,0.0
+"Accueil, hôtellerie, tourisme","Finances, banque, assurances",5,0.016790919470750218,0.0
+Autres...,Spécialités littéraires et artistiques plurivalentes,5,0.016790919470750218,0.0
+"Finances, banque, assurances","Français, littérature et civilisation françaises",5,0.016790919470750218,31.0
+"Langues vivantes, civilisations étrangères et régionales","Vie familiale, vie sociale et autres formations au développement personnel",5,0.016790919470750218,0.0
+Arts plastiques,Textile,5,0.016790919470750218,153.0
+Développement des capacités individuelles d'organisation,Economie,5,0.016790919470750218,0.0
+"Agro-alimentaire, alimentation, cuisine",Arts plastiques,5,0.016790919470750218,0.0
+Economie,"Langues vivantes, civilisations étrangères et régionales",5,0.016790919470750218,0.0
+Sciences de la vie,Spécialités pluriscientifiques,5,0.016790919470750218,0.0
+"Comptabilité, gestion",Spécialités concernant plusieurs capacités,5,0.016790919470750218,0.0
+Langues et civilisations anciennes,Linguistique,5,0.016790919470750218,0.0
+"Français, littérature et civilisation françaises","Sciences sociales (y compris démographie, anthropologie)",5,0.016790919470750218,0.0
+Linguistique,"Mathématiques, statistiques",5,0.016790919470750218,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Matériaux de construction, verre, céramique",5,0.016790919470750218,0.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes des échanges et de la gestion,5,0.016790919470750218,8.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Travail du bois et de l'ameublement,5,0.016790919470750218,0.0
+"Accueil, hôtellerie, tourisme","Français, littérature et civilisation françaises",5,0.016790919470750218,130.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Développement des capacités comportementales et relationnelles,5,0.016790919470750218,0.0
+"Langues vivantes, civilisations étrangères et régionales",Sciences de la terre,5,0.016790919470750218,0.0
+Spécialités pluritechnologiques des transformations,Transformations chimiques et apparentées (y compris pharmaceutiques),5,0.016790919470750218,66.0
+Formations générales,Langues et civilisations anciennes,5,0.016790919470750218,493.0
+"Electricité, électronique (non compris automatisme et productique)",Physique,5,0.016790919470750218,0.0
+"Droit, sciences politiques","Techniques de l'image et du son, métiers connexes du spectacle",5,0.016790919470750218,0.0
+Application des droits et statuts des personnes,"Comptabilité, gestion",5,0.016790919470750218,296.0
+Economie,Spécialités pluriscientifiques,5,0.016790919470750218,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,0.0
+"Electricité, électronique (non compris automatisme et productique)","Mathématiques, statistiques",5,0.016790919470750218,0.0
+"Nettoyage, assainissement, protection de l'environnement",Transformations chimiques et apparentées (y compris pharmaceutiques),5,0.016790919470750218,50.0
+Autres...,Physique,5,0.016790919470750218,0.0
+"Mécanique générale et de précision, usinage","Productions végétales,cultures spécialisées",5,0.016790919470750218,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Santé,5,0.016790919470750218,55.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités plurivalentes sanitaires et sociales,5,0.016790919470750218,0.0
+"Accueil, hôtellerie, tourisme",Bâtiment: finitions,5,0.016790919470750218,268.0
+Spécialités pluritechnologiques des transformations,Spécialités plurivalentes de la communication,5,0.016790919470750218,58.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Mécanique générale et de précision, usinage",5,0.016790919470750218,0.0
+Développement des capacités individuelles d'organisation,"Transport, manutention, magasinage",5,0.016790919470750218,579.5
+"Matériaux de construction, verre, céramique","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",5,0.016790919470750218,234.0
+"Enseignement, formation","Forêts, espaces naturels, faune sauvage, pêche",5,0.016790919470750218,40.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Technologies industrielles fondamentales,5,0.016790919470750218,0.0
+"Agro-alimentaire, alimentation, cuisine",Développement des capacités individuelles d'organisation,5,0.016790919470750218,138.0
+"Agro-alimentaire, alimentation, cuisine",Développement des capacités mentales et apprentissages de base,5,0.016790919470750218,95.0
+"Langues vivantes, civilisations étrangères et régionales","Mécanique générale et de précision, usinage",5,0.016790919470750218,0.0
+Spécialités concernant plusieurs capacités,Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,0.0
+Formations générales,Textile,5,0.016790919470750218,0.0
+Spécialités concernant plusieurs capacités,Technologies industrielles fondamentales,5,0.016790919470750218,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Nettoyage, assainissement, protection de l'environnement",5,0.016790919470750218,73.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Musique, arts du spectacle",5,0.016790919470750218,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Travail du bois et de l'ameublement,5,0.016790919470750218,0.0
+Application des droits et statuts des personnes,"Commerce, vente",5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités plurivalentes des services à la collectivité,5,0.016790919470750218,148.0
+"Accueil, hôtellerie, tourisme","Productions végétales,cultures spécialisées",5,0.016790919470750218,0.0
+Bâtiment: construction et couverture,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",5,0.016790919470750218,185.0
+Autres...,"Forêts, espaces naturels, faune sauvage, pêche",5,0.016790919470750218,40.0
+"Sécurité des biens et des personnes, police, surveillance",Technologies industrielles fondamentales,5,0.016790919470750218,0.0
+"Mécanique générale et de précision, usinage","Secrétariat, bureautique",5,0.016790919470750218,0.0
+Bâtiment: finitions,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",5,0.016790919470750218,320.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités plurivalentes des services à la collectivité,5,0.016790919470750218,166.0
+"Comptabilité, gestion","Vie familiale, vie sociale et autres formations au développement personnel",5,0.016790919470750218,0.0
+"Philosophie, éthique et théologie","Ressources humaines, gestion du personnel, gestion de l'emploi",5,0.016790919470750218,0.0
+Journalisme et communication,Spécialités plurivalentes des échanges et de la gestion,5,0.016790919470750218,151.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes des échanges et de la gestion,5,0.016790919470750218,166.33333333333334
+Psychologie,Spécialités pluriscientifiques,5,0.016790919470750218,65.0
+"Droit, sciences politiques",Spécialités pluritechnologiques des transformations,5,0.016790919470750218,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Spécialités pluridisciplinaires, sciences humaines et droit",5,0.016790919470750218,55.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Spécialités plurivalentes des services,5,0.016790919470750218,16.0
+"Aménagement du territoire, développement, urbanisme","Transport, manutention, magasinage",5,0.016790919470750218,193.0
+"Mécanique générale et de précision, usinage","Ressources humaines, gestion du personnel, gestion de l'emploi",5,0.016790919470750218,57.0
+Santé,Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,663.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Informatique, traitement de l'information, réseaux de transmission des données",5,0.016790919470750218,0.0
+Application des droits et statuts des personnes,"Secrétariat, bureautique",5,0.016790919470750218,0.0
+"Nettoyage, assainissement, protection de l'environnement",Technologies industrielles fondamentales,5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Productions végétales,cultures spécialisées",5,0.016790919470750218,72.0
+Journalisme et communication,Spécialités plurivalentes sanitaires et sociales,5,0.016790919470750218,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Autres disciplines artistiques et spécialités artistiques plurivalentes,5,0.016790919470750218,170.0
+"Français, littérature et civilisation françaises","Transport, manutention, magasinage",5,0.016790919470750218,0.0
+"Habillement (y compris mode, couture)","Transport, manutention, magasinage",5,0.016790919470750218,92.5
+"Spécialités pluritechnologiques, génie civil, construction, bois","Techniques de l'image et du son, métiers connexes du spectacle",5,0.016790919470750218,66.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Technologies de commandes des transformations industrielles,5,0.016790919470750218,24.0
+"Productions végétales,cultures spécialisées","Spécialités plutitechnologiques, mécanique-électricité",5,0.016790919470750218,195.0
+"Accueil, hôtellerie, tourisme","Aménagement paysager (parcs, jardins, espaces verts)",5,0.016790919470750218,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Textile,5,0.016790919470750218,170.0
+Psychologie,Spécialités plurivalentes des échanges et de la gestion,5,0.016790919470750218,212.66666666666666
+Spécialités plurivalentes de l'agronomie et de l'agriculture,"Sécurité des biens et des personnes, police, surveillance",5,0.016790919470750218,368.0
+"Droit, sciences politiques",Spécialités plurivalentes sanitaires et sociales,5,0.016790919470750218,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,76.0
+Economie,Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,0.0
+"Agro-alimentaire, alimentation, cuisine",Travail du bois et de l'ameublement,5,0.016790919470750218,112.5
+Sciences de la terre,"Spécialités pluridisciplinaires, sciences humaines et droit",5,0.016790919470750218,211.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Electricité, électronique (non compris automatisme et productique)",5,0.016790919470750218,2603.0
+"Langues vivantes, civilisations étrangères et régionales",Spécialités plurivalentes de l'agronomie et de l'agriculture,5,0.016790919470750218,0.0
+Chimie,Spécialités pluriscientifiques,5,0.016790919470750218,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes sanitaires et sociales,5,0.016790919470750218,0.0
+Moteurs et mécanique auto,Travail du bois et de l'ameublement,5,0.016790919470750218,0.0
+"Agro-alimentaire, alimentation, cuisine",Autres disciplines artistiques et spécialités artistiques plurivalentes,5,0.016790919470750218,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Travail social,5,0.016790919470750218,0.0
+Linguistique,"Productions végétales,cultures spécialisées",5,0.016790919470750218,0.0
+Bâtiment: construction et couverture,Moteurs et mécanique auto,5,0.016790919470750218,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Travail du bois et de l'ameublement,5,0.016790919470750218,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,"Spécialités plutitechnologiques, mécanique-électricité",5,0.016790919470750218,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités pluriscientifiques,4,0.013432735576600175,250.0
+Bâtiment: finitions,"Nettoyage, assainissement, protection de l'environnement",4,0.013432735576600175,0.0
+"Comptabilité, gestion","Documentation, bibliothèques, administration des données",4,0.013432735576600175,0.0
+Economie,Travail social,4,0.013432735576600175,0.0
+"Enseignement, formation",Textile,4,0.013432735576600175,0.0
+"Animation culturelle, sportive et de loisirs",Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,200.0
+Journalisme et communication,Spécialités concernant plusieurs capacités,4,0.013432735576600175,230.0
+"Documentation, bibliothèques, administration des données",Spécialités plurivalentes des échanges et de la gestion,4,0.013432735576600175,33.0
+"Habillement (y compris mode, couture)",Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+Journalisme et communication,Pratiques sportives,4,0.013432735576600175,0.0
+Santé,Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+Santé,"Spécialités pluritechnologiques, génie civil, construction, bois",4,0.013432735576600175,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Bâtiment: construction et couverture,4,0.013432735576600175,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes sanitaires et sociales,4,0.013432735576600175,56.0
+"Energie, génie climatique","Finances, banque, assurances",4,0.013432735576600175,852.0
+"Enseignement, formation",Mécanique aéronautique et spatiale,4,0.013432735576600175,10.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Droit, sciences politiques",4,0.013432735576600175,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités concernant plusieurs capacités,4,0.013432735576600175,175.5
+"Chimie-biologie, biochimie","Enseignement, formation",4,0.013432735576600175,0.0
+Développement des capacités individuelles d'organisation,"Techniques de l'image et du son, métiers connexes du spectacle",4,0.013432735576600175,0.0
+Moteurs et mécanique auto,Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Travail du bois et de l'ameublement,4,0.013432735576600175,136.0
+"Nettoyage, assainissement, protection de l'environnement",Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,200.0
+Physique-chimie,Sciences de la vie,4,0.013432735576600175,0.0
+Géographie,"Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+Histoire,"Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+Développement des capacités comportementales et relationnelles,Sciences de la vie,4,0.013432735576600175,65.0
+Développement des capacités mentales et apprentissages de base,Spécialités plurivalentes des services,4,0.013432735576600175,0.0
+Spécialités concernant plusieurs capacités,Spécialités pluriscientifiques,4,0.013432735576600175,0.0
+Spécialités militaires,"Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,255.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,54.0
+Autres...,Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,0.0
+"Français, littérature et civilisation françaises",Travail social,4,0.013432735576600175,3.0
+Protection et développement du patrimoine,"Ressources humaines, gestion du personnel, gestion de l'emploi",4,0.013432735576600175,50.0
+"Enseignement, formation",Spécialités plurivalentes des services à la collectivité,4,0.013432735576600175,0.0
+Développement des capacités mentales et apprentissages de base,"Finances, banque, assurances",4,0.013432735576600175,0.0
+"Droit, sciences politiques","Vie familiale, vie sociale et autres formations au développement personnel",4,0.013432735576600175,0.0
+"Productions végétales,cultures spécialisées",Sciences de la terre,4,0.013432735576600175,0.0
+Chimie,"Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,0.0
+"Agro-alimentaire, alimentation, cuisine",Economie,4,0.013432735576600175,0.0
+Bâtiment: finitions,Protection et développement du patrimoine,4,0.013432735576600175,0.0
+Spécialités pluritechnologiques des transformations,Technologies de commandes des transformations industrielles,4,0.013432735576600175,0.0
+"Mathématiques, statistiques",Santé,4,0.013432735576600175,0.0
+Développement des capacités individuelles d'organisation,"Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,86.0
+Bâtiment: finitions,Développement des capacités comportementales et relationnelles,4,0.013432735576600175,364.0
+Bâtiment: construction et couverture,Economie,4,0.013432735576600175,0.0
+"Aménagement du territoire, développement, urbanisme",Géographie,4,0.013432735576600175,0.0
+Autres...,Géographie,4,0.013432735576600175,0.0
+"Musique, arts du spectacle",Travail social,4,0.013432735576600175,126.0
+Spécialités pluritechnologiques des transformations,"Spécialités pluritechnologiques, matériaux souples",4,0.013432735576600175,0.0
+Journalisme et communication,"Spécialités pluritechnologiques, génie civil, construction, bois",4,0.013432735576600175,211.0
+Développement des capacités individuelles d'organisation,"Finances, banque, assurances",4,0.013432735576600175,0.0
+"Aménagement du territoire, développement, urbanisme",Développement des capacités comportementales et relationnelles,4,0.013432735576600175,21.0
+Langues et civilisations anciennes,"Secrétariat, bureautique",4,0.013432735576600175,125.0
+"Mécanique générale et de précision, usinage","Plasturgie, matériaux composites",4,0.013432735576600175,0.0
+Développement des capacités comportementales et relationnelles,"Plasturgie, matériaux composites",4,0.013432735576600175,188.66666666666666
+Spécialités plurivalentes sanitaires et sociales,"Techniques de l'image et du son, métiers connexes du spectacle",4,0.013432735576600175,0.0
+"Chimie-biologie, biochimie","Nettoyage, assainissement, protection de l'environnement",4,0.013432735576600175,71.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Développement des capacités mentales et apprentissages de base,4,0.013432735576600175,0.0
+"Documentation, bibliothèques, administration des données","Mathématiques, statistiques",4,0.013432735576600175,0.0
+Bâtiment: construction et couverture,Chimie,4,0.013432735576600175,817.5
+"Droit, sciences politiques",Techniques de l'imprimerie et de l'édition,4,0.013432735576600175,0.0
+Géographie,"Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,0.0
+Histoire,"Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,0.0
+Arts plastiques,"Habillement (y compris mode, couture)",4,0.013432735576600175,0.0
+"Philosophie, éthique et théologie","Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+"Commerce, vente",Histoire,4,0.013432735576600175,0.0
+"Langues vivantes, civilisations étrangères et régionales",Travail du bois et de l'ameublement,4,0.013432735576600175,200.0
+"Droit, sciences politiques",Sciences de la terre,4,0.013432735576600175,0.0
+Autres...,"Plasturgie, matériaux composites",4,0.013432735576600175,42.0
+Formations générales,Histoire,4,0.013432735576600175,0.0
+Jeux et activités spécifiques de loisirs,"Vie familiale, vie sociale et autres formations au développement personnel",4,0.013432735576600175,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Développement des capacités individuelles d'organisation,4,0.013432735576600175,85.0
+"Forêts, espaces naturels, faune sauvage, pêche",Sciences de la vie,4,0.013432735576600175,0.0
+"Français, littérature et civilisation françaises",Psychologie,4,0.013432735576600175,0.0
+Chimie,Sciences de la vie,4,0.013432735576600175,0.0
+Sciences de la vie,"Secrétariat, bureautique",4,0.013432735576600175,0.0
+Autres...,Sciences de la vie,4,0.013432735576600175,0.0
+Sciences de la terre,Spécialités pluriscientifiques,4,0.013432735576600175,0.0
+Développement des capacités individuelles d'organisation,Spécialités plurivalentes des services,4,0.013432735576600175,0.0
+"Agro-alimentaire, alimentation, cuisine",Sciences de la vie,4,0.013432735576600175,0.0
+Linguistique,"Vie familiale, vie sociale et autres formations au développement personnel",4,0.013432735576600175,33.0
+"Nettoyage, assainissement, protection de l'environnement","Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,0.0
+"Enseignement, formation",Physique-chimie,4,0.013432735576600175,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Textile,4,0.013432735576600175,1823.0
+"Enseignement, formation","Habillement (y compris mode, couture)",4,0.013432735576600175,160.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Ressources humaines, gestion du personnel, gestion de l'emploi",4,0.013432735576600175,96.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Bâtiment: finitions,4,0.013432735576600175,0.0
+"Techniques de l'image et du son, métiers connexes du spectacle",Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+"Accueil, hôtellerie, tourisme",Pratiques sportives,4,0.013432735576600175,0.0
+"Habillement (y compris mode, couture)",Journalisme et communication,4,0.013432735576600175,0.0
+Pratiques sportives,Psychologie,4,0.013432735576600175,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,9.0
+"Energie, génie climatique",Physique,4,0.013432735576600175,0.0
+"Comptabilité, gestion",Moteurs et mécanique auto,4,0.013432735576600175,0.0
+"Enseignement, formation",Techniques de l'imprimerie et de l'édition,4,0.013432735576600175,0.0
+Chimie,Sciences de la terre,4,0.013432735576600175,0.0
+Chimie,Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,63.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Mines et carrières, génie civil, topographie",4,0.013432735576600175,1294.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Sciences de la vie,4,0.013432735576600175,0.0
+Economie,"Productions végétales,cultures spécialisées",4,0.013432735576600175,0.0
+"Enseignement, formation","Mines et carrières, génie civil, topographie",4,0.013432735576600175,0.0
+Physique-chimie,Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,0.0
+"Musique, arts du spectacle","Secrétariat, bureautique",4,0.013432735576600175,74.5
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités pluriscientifiques,4,0.013432735576600175,0.0
+"Finances, banque, assurances",Spécialités pluriscientifiques,4,0.013432735576600175,495.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Techniques de l'imprimerie et de l'édition,4,0.013432735576600175,183.5
+"Documentation, bibliothèques, administration des données","Droit, sciences politiques",4,0.013432735576600175,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Sciences de la vie,4,0.013432735576600175,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Pratiques sportives,4,0.013432735576600175,0.0
+"Droit, sciences politiques",Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+Pratiques sportives,Spécialités plurivalentes des échanges et de la gestion,4,0.013432735576600175,27.0
+"Productions végétales,cultures spécialisées",Travail du bois et de l'ameublement,4,0.013432735576600175,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Sciences naturelles (Biologie-Géologie),4,0.013432735576600175,43.0
+Formations générales,"Plasturgie, matériaux composites",4,0.013432735576600175,0.0
+Journalisme et communication,Spécialités plurivalentes de l'agronomie et de l'agriculture,4,0.013432735576600175,0.0
+"Secrétariat, bureautique",Technologies de commandes des transformations industrielles,4,0.013432735576600175,20.0
+Développement des capacités individuelles d'organisation,"Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+Spécialités pluriscientifiques,"Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Secrétariat, bureautique",4,0.013432735576600175,0.0
+"Comptabilité, gestion",Spécialités pluriscientifiques,4,0.013432735576600175,0.0
+Formations générales,Sciences de la terre,4,0.013432735576600175,0.0
+"Aménagement du territoire, développement, urbanisme",Formations générales,4,0.013432735576600175,0.0
+Développement des capacités individuelles d'organisation,"Français, littérature et civilisation françaises",4,0.013432735576600175,0.0
+"Agro-alimentaire, alimentation, cuisine","Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,0.0
+"Mathématiques, statistiques","Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Sciences sociales (y compris démographie, anthropologie)",4,0.013432735576600175,0.0
+Développement des capacités comportementales et relationnelles,Physique-chimie,4,0.013432735576600175,0.0
+Spécialités pluritechnologiques des transformations,Spécialités plurivalentes des services,4,0.013432735576600175,240.0
+"Chimie-biologie, biochimie",Spécialités plurivalentes de l'agronomie et de l'agriculture,4,0.013432735576600175,0.0
+"Français, littérature et civilisation françaises","Vie familiale, vie sociale et autres formations au développement personnel",4,0.013432735576600175,207.0
+Chimie,"Transport, manutention, magasinage",4,0.013432735576600175,1088.0
+"Documentation, bibliothèques, administration des données",Formations générales,4,0.013432735576600175,1062.0
+Spécialités pluritechnologiques des transformations,"Transport, manutention, magasinage",4,0.013432735576600175,0.0
+Economie,"Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,19.0
+Chimie,"Langues vivantes, civilisations étrangères et régionales",4,0.013432735576600175,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Spécialités plurivalentes de la communication,4,0.013432735576600175,70.5
+"Finances, banque, assurances",Spécialités plurivalentes sanitaires et sociales,4,0.013432735576600175,59.5
+"Mines et carrières, génie civil, topographie",Santé,4,0.013432735576600175,708.0
+"Mines et carrières, génie civil, topographie","Spécialités plutitechnologiques, mécanique-électricité",4,0.013432735576600175,99.0
+Psychologie,"Secrétariat, bureautique",4,0.013432735576600175,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes des services à la collectivité,4,0.013432735576600175,1146.0
+"Commerce, vente",Physique-chimie,4,0.013432735576600175,85.0
+"Plasturgie, matériaux composites",Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+"Mécanique générale et de précision, usinage","Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,0.0
+Bâtiment: construction et couverture,Spécialités plurivalentes de l'agronomie et de l'agriculture,4,0.013432735576600175,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités plurivalentes des services,4,0.013432735576600175,99.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Techniques de l'imprimerie et de l'édition,4,0.013432735576600175,0.0
+"Finances, banque, assurances",Travail social,4,0.013432735576600175,0.0
+"Productions végétales,cultures spécialisées","Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,466.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Transformations chimiques et apparentées (y compris pharmaceutiques),4,0.013432735576600175,0.0
+"Animation culturelle, sportive et de loisirs",Linguistique,4,0.013432735576600175,0.0
+Bâtiment: construction et couverture,"Mécanique générale et de précision, usinage",4,0.013432735576600175,156.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités plurivalentes des services,4,0.013432735576600175,0.0
+Linguistique,"Mécanique générale et de précision, usinage",4,0.013432735576600175,119.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités plurivalentes des échanges et de la gestion,4,0.013432735576600175,0.0
+Bâtiment: construction et couverture,"Français, littérature et civilisation françaises",4,0.013432735576600175,55.0
+"Finances, banque, assurances","Sécurité des biens et des personnes, police, surveillance",4,0.013432735576600175,141.0
+Spécialités pluriscientifiques,Spécialités plurivalentes des services,4,0.013432735576600175,0.0
+"Mécanique générale et de précision, usinage","Productions animales, élevage spécialisé, aquaculture, ...",4,0.013432735576600175,534.0
+Bâtiment: finitions,Linguistique,4,0.013432735576600175,142.0
+Linguistique,Spécialités pluriscientifiques,4,0.013432735576600175,66.0
+Bâtiment: finitions,"Langues vivantes, civilisations étrangères et régionales",4,0.013432735576600175,35.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Spécialités pluritechnologiques, génie civil, construction, bois",4,0.013432735576600175,0.0
+Bâtiment: construction et couverture,"Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,93.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités plurivalentes de l'agronomie et de l'agriculture,4,0.013432735576600175,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Productions animales, élevage spécialisé, aquaculture, ...",4,0.013432735576600175,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Technologies de commandes des transformations industrielles,4,0.013432735576600175,133.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Energie, génie climatique",4,0.013432735576600175,0.0
+"Productions végétales,cultures spécialisées",Santé,4,0.013432735576600175,72.0
+Spécialités pluriscientifiques,"Transport, manutention, magasinage",4,0.013432735576600175,30.0
+Bâtiment: finitions,Moteurs et mécanique auto,4,0.013432735576600175,180.0
+"Electricité, électronique (non compris automatisme et productique)",Travail du bois et de l'ameublement,4,0.013432735576600175,59.0
+Linguistique,"Mines et carrières, génie civil, topographie",4,0.013432735576600175,0.0
+"Langues vivantes, civilisations étrangères et régionales",Spécialités pluritechnologiques des transformations,4,0.013432735576600175,0.0
+"Droit, sciences politiques",Technologies de commandes des transformations industrielles,4,0.013432735576600175,0.0
+"Droit, sciences politiques",Spécialités littéraires et artistiques plurivalentes,4,0.013432735576600175,0.0
+"Energie, génie climatique","Secrétariat, bureautique",4,0.013432735576600175,0.0
+Linguistique,"Productions animales, élevage spécialisé, aquaculture, ...",4,0.013432735576600175,0.0
+"Techniques de l'image et du son, métiers connexes du spectacle","Transport, manutention, magasinage",4,0.013432735576600175,0.0
+Spécialités plurivalentes des échanges et de la gestion,Textile,4,0.013432735576600175,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Travail du bois et de l'ameublement,4,0.013432735576600175,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Développement des capacités mentales et apprentissages de base,4,0.013432735576600175,0.0
+"Accueil, hôtellerie, tourisme","Productions animales, élevage spécialisé, aquaculture, ...",4,0.013432735576600175,0.0
+"Energie, génie climatique","Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+"Electricité, électronique (non compris automatisme et productique)","Spécialités pluridisciplinaires, sciences humaines et droit",4,0.013432735576600175,0.0
+Economie,"Electricité, électronique (non compris automatisme et productique)",4,0.013432735576600175,0.0
+Spécialités plurivalentes des services,Structures métalliques,4,0.013432735576600175,0.0
+Physique-chimie,Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+"Agro-alimentaire, alimentation, cuisine",Langues et civilisations anciennes,4,0.013432735576600175,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",4,0.013432735576600175,0.0
+Moteurs et mécanique auto,"Productions végétales,cultures spécialisées",4,0.013432735576600175,0.0
+Linguistique,Moteurs et mécanique auto,4,0.013432735576600175,0.0
+"Chimie-biologie, biochimie",Technologies industrielles fondamentales,4,0.013432735576600175,0.0
+"Langues vivantes, civilisations étrangères et régionales","Productions animales, élevage spécialisé, aquaculture, ...",4,0.013432735576600175,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Santé,4,0.013432735576600175,0.0
+Développement des capacités individuelles d'organisation,"Electricité, électronique (non compris automatisme et productique)",3,0.01007455168245013,256.0
+Economie et activités domestiques,"Informatique, traitement de l'information, réseaux de transmission des données",3,0.01007455168245013,0.0
+"Aménagement du territoire, développement, urbanisme","Secrétariat, bureautique",3,0.01007455168245013,236.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes des services à la collectivité,3,0.01007455168245013,0.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes de l'agronomie et de l'agriculture,3,0.01007455168245013,0.0
+"Accueil, hôtellerie, tourisme",Développement des capacités mentales et apprentissages de base,3,0.01007455168245013,0.0
+"Electricité, électronique (non compris automatisme et productique)","Français, littérature et civilisation françaises",3,0.01007455168245013,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Energie, génie climatique",3,0.01007455168245013,0.0
+Autres...,"Philosophie, éthique et théologie",3,0.01007455168245013,0.0
+"Chimie-biologie, biochimie","Productions végétales,cultures spécialisées",3,0.01007455168245013,0.0
+"Droit, sciences politiques","Productions animales, élevage spécialisé, aquaculture, ...",3,0.01007455168245013,182.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Psychologie,3,0.01007455168245013,0.0
+"Musique, arts du spectacle","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,0.0
+"Philosophie, éthique et théologie","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités plurivalentes des échanges et de la gestion,3,0.01007455168245013,0.0
+Economie et activités domestiques,"Finances, banque, assurances",3,0.01007455168245013,0.0
+Arts plastiques,Bâtiment: construction et couverture,3,0.01007455168245013,0.0
+Géographie,"Mathématiques, statistiques",3,0.01007455168245013,0.0
+Bâtiment: construction et couverture,"Mathématiques, statistiques",3,0.01007455168245013,0.0
+"Commerce, vente",Sciences de la terre,3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,Sciences de la terre,3,0.01007455168245013,0.0
+Développement des capacités comportementales et relationnelles,Techniques de l'imprimerie et de l'édition,3,0.01007455168245013,41.0
+Journalisme et communication,Textile,3,0.01007455168245013,0.0
+"Philosophie, éthique et théologie",Sciences de la vie,3,0.01007455168245013,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Sciences de la terre,3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,Textile,3,0.01007455168245013,0.0
+Santé,Spécialités militaires,3,0.01007455168245013,0.0
+Jeux et activités spécifiques de loisirs,Santé,3,0.01007455168245013,0.0
+"Musique, arts du spectacle","Sciences sociales (y compris démographie, anthropologie)",3,0.01007455168245013,23.0
+Economie,"Nettoyage, assainissement, protection de l'environnement",3,0.01007455168245013,69.0
+"Droit, sciences politiques",Spécialités plurivalentes des services à la collectivité,3,0.01007455168245013,0.0
+Développement des capacités mentales et apprentissages de base,Spécialités pluriscientifiques,3,0.01007455168245013,136.0
+Jeux et activités spécifiques de loisirs,Spécialités concernant plusieurs capacités,3,0.01007455168245013,0.0
+Protection et développement du patrimoine,"Sécurité des biens et des personnes, police, surveillance",3,0.01007455168245013,197.0
+"Animation culturelle, sportive et de loisirs","Sciences sociales (y compris démographie, anthropologie)",3,0.01007455168245013,38.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Secrétariat, bureautique",3,0.01007455168245013,297.0
+Santé,Transformations chimiques et apparentées (y compris pharmaceutiques),3,0.01007455168245013,58.0
+"Sciences sociales (y compris démographie, anthropologie)","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Spécialités plurivalentes des services à la collectivité,3,0.01007455168245013,198.0
+"Animation culturelle, sportive et de loisirs","Spécialités pluridisciplinaires, sciences humaines et droit",3,0.01007455168245013,0.0
+"Finances, banque, assurances","Habillement (y compris mode, couture)",3,0.01007455168245013,0.0
+"Habillement (y compris mode, couture)",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+Chimie,"Enseignement, formation",3,0.01007455168245013,0.0
+"Energie, génie climatique",Physique-chimie,3,0.01007455168245013,0.0
+Développement des capacités comportementales et relationnelles,Spécialités militaires,3,0.01007455168245013,0.0
+"Energie, génie climatique","Forêts, espaces naturels, faune sauvage, pêche",3,0.01007455168245013,133.0
+"Finances, banque, assurances",Psychologie,3,0.01007455168245013,0.0
+"Mathématiques, statistiques","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,262.0
+"Aménagement du territoire, développement, urbanisme",Développement des capacités individuelles d'organisation,3,0.01007455168245013,0.0
+Psychologie,Spécialités littéraires et artistiques plurivalentes,3,0.01007455168245013,0.0
+Psychologie,Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+"Français, littérature et civilisation françaises",Sciences naturelles (Biologie-Géologie),3,0.01007455168245013,0.0
+Autres...,Sciences de la terre,3,0.01007455168245013,0.0
+"Mécanique générale et de précision, usinage",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,"Energie, génie climatique",3,0.01007455168245013,0.0
+Bâtiment: finitions,"Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+Bâtiment: construction et couverture,"Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,151.0
+"Matériaux de construction, verre, céramique",Spécialités pluritechnologiques des transformations,3,0.01007455168245013,0.0
+Formations générales,"Papier, carton",3,0.01007455168245013,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Histoire,3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,"Musique, arts du spectacle",3,0.01007455168245013,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Travail social,3,0.01007455168245013,0.0
+Bâtiment: finitions,Développement des capacités mentales et apprentissages de base,3,0.01007455168245013,0.0
+Bâtiment: construction et couverture,"Finances, banque, assurances",3,0.01007455168245013,55.5
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Electricité, électronique (non compris automatisme et productique)",3,0.01007455168245013,140.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+Pratiques sportives,Spécialités militaires,3,0.01007455168245013,0.0
+Autres...,Economie et activités domestiques,3,0.01007455168245013,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Travail du bois et de l'ameublement,3,0.01007455168245013,22.0
+Jeux et activités spécifiques de loisirs,Linguistique,3,0.01007455168245013,0.0
+"Nettoyage, assainissement, protection de l'environnement",Sciences de la vie,3,0.01007455168245013,0.0
+Pratiques sportives,"Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Habillement (y compris mode, couture)",3,0.01007455168245013,65.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,0.0
+"Animation culturelle, sportive et de loisirs","Coiffure, esthétique et autres spécialités des services aux personnes",3,0.01007455168245013,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Pratiques sportives,3,0.01007455168245013,0.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+Développement des capacités mentales et apprentissages de base,"Spécialités pluridisciplinaires, sciences humaines et droit",3,0.01007455168245013,0.0
+"Mathématiques, statistiques",Spécialités plurivalentes de la communication,3,0.01007455168245013,0.0
+"Langues vivantes, civilisations étrangères et régionales","Philosophie, éthique et théologie",3,0.01007455168245013,0.0
+Physique,Santé,3,0.01007455168245013,0.0
+"Enseignement, formation",Sciences naturelles (Biologie-Géologie),3,0.01007455168245013,0.0
+Arts plastiques,Santé,3,0.01007455168245013,0.0
+"Aménagement du territoire, développement, urbanisme",Sciences de la vie,3,0.01007455168245013,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,41.0
+Autres...,Langues et civilisations anciennes,3,0.01007455168245013,0.0
+Arts plastiques,Histoire,3,0.01007455168245013,0.0
+"Chimie-biologie, biochimie",Linguistique,3,0.01007455168245013,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Chimie,3,0.01007455168245013,0.0
+Autres...,Chimie,3,0.01007455168245013,0.0
+Arts plastiques,Développement des capacités comportementales et relationnelles,3,0.01007455168245013,0.0
+Application des droits et statuts des personnes,Spécialités plurivalentes sanitaires et sociales,3,0.01007455168245013,289.0
+"Musique, arts du spectacle",Techniques de l'imprimerie et de l'édition,3,0.01007455168245013,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Comptabilité, gestion",3,0.01007455168245013,0.0
+Spécialités plurivalentes des services,Techniques de l'imprimerie et de l'édition,3,0.01007455168245013,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités concernant plusieurs capacités,3,0.01007455168245013,264.5
+"Spécialités pluritechnologiques, matériaux souples",Spécialités plurivalentes de la communication,3,0.01007455168245013,0.0
+Application des droits et statuts des personnes,Psychologie,3,0.01007455168245013,61.0
+"Animation culturelle, sportive et de loisirs","Droit, sciences politiques",3,0.01007455168245013,0.0
+Histoire,Journalisme et communication,3,0.01007455168245013,0.0
+"Enseignement, formation",Spécialités pluritechnologiques des transformations,3,0.01007455168245013,0.0
+"Musique, arts du spectacle",Physique,3,0.01007455168245013,0.0
+Physique,"Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,0.0
+"Accueil, hôtellerie, tourisme","Aménagement du territoire, développement, urbanisme",3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+"Nettoyage, assainissement, protection de l'environnement",Protection et développement du patrimoine,3,0.01007455168245013,0.0
+Arts plastiques,Linguistique,3,0.01007455168245013,0.0
+Développement des capacités individuelles d'organisation,Jeux et activités spécifiques de loisirs,3,0.01007455168245013,0.0
+Bâtiment: finitions,"Plasturgie, matériaux composites",3,0.01007455168245013,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Transformations chimiques et apparentées (y compris pharmaceutiques),3,0.01007455168245013,0.0
+Autres...,Mécanique aéronautique et spatiale,3,0.01007455168245013,91.0
+Arts plastiques,"Secrétariat, bureautique",3,0.01007455168245013,0.0
+"Mines et carrières, génie civil, topographie",Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+Chimie,Spécialités pluritechnologiques des transformations,3,0.01007455168245013,0.0
+"Productions végétales,cultures spécialisées",Spécialités pluritechnologiques des transformations,3,0.01007455168245013,8.0
+Bâtiment: construction et couverture,"Plasturgie, matériaux composites",3,0.01007455168245013,0.0
+Spécialités plurivalentes des services,Spécialités plurivalentes des services à la collectivité,3,0.01007455168245013,1146.0
+Spécialités plurivalentes des services à la collectivité,Spécialités plurivalentes des échanges et de la gestion,3,0.01007455168245013,174.0
+"Mathématiques, statistiques",Psychologie,3,0.01007455168245013,0.0
+"Matériaux de construction, verre, céramique",Technologies industrielles fondamentales,3,0.01007455168245013,372.0
+"Energie, génie climatique",Transformations chimiques et apparentées (y compris pharmaceutiques),3,0.01007455168245013,196.0
+"Transport, manutention, magasinage","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,235.0
+"Productions végétales,cultures spécialisées",Spécialités pluriscientifiques,3,0.01007455168245013,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Pratiques sportives,3,0.01007455168245013,0.0
+"Transport, manutention, magasinage",Travail social,3,0.01007455168245013,105.0
+"Agro-alimentaire, alimentation, cuisine",Sciences de la terre,3,0.01007455168245013,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités pluriscientifiques,3,0.01007455168245013,0.0
+"Musique, arts du spectacle",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités concernant plusieurs capacités,3,0.01007455168245013,695.0
+Pratiques sportives,"Secrétariat, bureautique",3,0.01007455168245013,216.0
+Développement des capacités mentales et apprentissages de base,"Transport, manutention, magasinage",3,0.01007455168245013,0.0
+Développement des capacités mentales et apprentissages de base,Spécialités plurivalentes des échanges et de la gestion,3,0.01007455168245013,77.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Sécurité des biens et des personnes, police, surveillance",3,0.01007455168245013,93.0
+Mécanique aéronautique et spatiale,"Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,0.0
+"Agro-alimentaire, alimentation, cuisine",Chimie,3,0.01007455168245013,713.0
+"Comptabilité, gestion","Habillement (y compris mode, couture)",3,0.01007455168245013,0.0
+"Accueil, hôtellerie, tourisme",Spécialités concernant plusieurs capacités,3,0.01007455168245013,0.0
+"Productions végétales,cultures spécialisées",Spécialités plurivalentes des échanges et de la gestion,3,0.01007455168245013,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Transformations chimiques et apparentées (y compris pharmaceutiques),3,0.01007455168245013,0.0
+"Secrétariat, bureautique","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+"Aménagement du territoire, développement, urbanisme",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+Pratiques sportives,Spécialités plurivalentes de la communication,3,0.01007455168245013,0.0
+Formations générales,Jeux et activités spécifiques de loisirs,3,0.01007455168245013,0.0
+"Energie, génie climatique",Spécialités plurivalentes des services,3,0.01007455168245013,240.0
+Bâtiment: finitions,Mécanique aéronautique et spatiale,3,0.01007455168245013,75.0
+Moteurs et mécanique auto,Spécialités pluritechnologiques des transformations,3,0.01007455168245013,0.0
+"Droit, sciences politiques","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+"Agro-alimentaire, alimentation, cuisine","Vie familiale, vie sociale et autres formations au développement personnel",3,0.01007455168245013,52.5
+"Coiffure, esthétique et autres spécialités des services aux personnes","Musique, arts du spectacle",3,0.01007455168245013,102.0
+"Mines et carrières, génie civil, topographie","Mécanique générale et de précision, usinage",3,0.01007455168245013,0.0
+Sciences de la terre,Spécialités plurivalentes de la communication,3,0.01007455168245013,0.0
+"Finances, banque, assurances","Nettoyage, assainissement, protection de l'environnement",3,0.01007455168245013,199.0
+Spécialités plurivalentes sanitaires et sociales,Technologies industrielles fondamentales,3,0.01007455168245013,560.0
+Santé,Technologies de commandes des transformations industrielles,3,0.01007455168245013,0.0
+Journalisme et communication,Spécialités littéraires et artistiques plurivalentes,3,0.01007455168245013,0.0
+Protection et développement du patrimoine,"Spécialités pluritechnologiques, génie civil, construction, bois",3,0.01007455168245013,0.0
+"Agro-alimentaire, alimentation, cuisine",Pratiques sportives,3,0.01007455168245013,0.0
+"Commerce, vente",Spécialités littéraires et artistiques plurivalentes,3,0.01007455168245013,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Mines et carrières, génie civil, topographie",3,0.01007455168245013,0.0
+"Chimie-biologie, biochimie","Spécialités pluridisciplinaires, sciences humaines et droit",3,0.01007455168245013,0.0
+"Commerce, vente",Jeux et activités spécifiques de loisirs,3,0.01007455168245013,154.0
+"Enseignement, formation","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",3,0.01007455168245013,93.0
+"Energie, génie climatique",Linguistique,3,0.01007455168245013,0.0
+"Philosophie, éthique et théologie",Spécialités plurivalentes sanitaires et sociales,3,0.01007455168245013,0.0
+Moteurs et mécanique auto,"Secrétariat, bureautique",3,0.01007455168245013,0.0
+"Comptabilité, gestion",Sciences de la terre,3,0.01007455168245013,0.0
+Moteurs et mécanique auto,Mécanique aéronautique et spatiale,3,0.01007455168245013,0.0
+Développement des capacités comportementales et relationnelles,"Forêts, espaces naturels, faune sauvage, pêche",3,0.01007455168245013,36.0
+Moteurs et mécanique auto,"Sécurité des biens et des personnes, police, surveillance",3,0.01007455168245013,13.0
+Journalisme et communication,"Productions animales, élevage spécialisé, aquaculture, ...",3,0.01007455168245013,0.0
+"Documentation, bibliothèques, administration des données",Santé,3,0.01007455168245013,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Spécialités pluritechnologiques, génie civil, construction, bois",3,0.01007455168245013,0.0
+"Agro-alimentaire, alimentation, cuisine","Finances, banque, assurances",3,0.01007455168245013,0.0
+"Electricité, électronique (non compris automatisme et productique)","Finances, banque, assurances",3,0.01007455168245013,0.0
+Pratiques sportives,"Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,41.0
+Linguistique,Spécialités plurivalentes de l'agronomie et de l'agriculture,3,0.01007455168245013,0.0
+"Matériaux de construction, verre, céramique","Spécialités pluritechnologiques, génie civil, construction, bois",3,0.01007455168245013,0.0
+Spécialités plurivalentes de la communication,"Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,397.0
+Développement des capacités comportementales et relationnelles,Transformations chimiques et apparentées (y compris pharmaceutiques),3,0.01007455168245013,8582.0
+Technologies de commandes des transformations industrielles,Travail du bois et de l'ameublement,3,0.01007455168245013,91.5
+Journalisme et communication,"Transport, manutention, magasinage",3,0.01007455168245013,0.0
+"Comptabilité, gestion",Textile,3,0.01007455168245013,0.0
+Chimie,"Spécialités pluritechnologiques, génie civil, construction, bois",3,0.01007455168245013,143.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Comptabilité, gestion",3,0.01007455168245013,12.0
+"Habillement (y compris mode, couture)","Secrétariat, bureautique",3,0.01007455168245013,0.0
+Psychologie,Technologies industrielles fondamentales,3,0.01007455168245013,68.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,41.0
+"Enseignement, formation","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,41.0
+"Chimie-biologie, biochimie",Spécialités plurivalentes des échanges et de la gestion,3,0.01007455168245013,30.0
+"Electricité, électronique (non compris automatisme et productique)","Plasturgie, matériaux composites",3,0.01007455168245013,177.0
+"Mines et carrières, génie civil, topographie","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",3,0.01007455168245013,369.0
+Bâtiment: construction et couverture,"Productions animales, élevage spécialisé, aquaculture, ...",3,0.01007455168245013,38.0
+"Finances, banque, assurances",Spécialités plurivalentes des services à la collectivité,3,0.01007455168245013,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Français, littérature et civilisation françaises",3,0.01007455168245013,484.0
+Chimie,Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+Spécialités concernant plusieurs capacités,"Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,673.0
+Bâtiment: construction et couverture,Structures métalliques,3,0.01007455168245013,657.0
+"Nettoyage, assainissement, protection de l'environnement",Travail du bois et de l'ameublement,3,0.01007455168245013,18.0
+"Productions végétales,cultures spécialisées","Ressources humaines, gestion du personnel, gestion de l'emploi",3,0.01007455168245013,62.0
+"Chimie-biologie, biochimie","Informatique, traitement de l'information, réseaux de transmission des données",3,0.01007455168245013,265.5
+Journalisme et communication,Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+Moteurs et mécanique auto,Spécialités plurivalentes des services,3,0.01007455168245013,429.0
+"Mathématiques, statistiques","Spécialités pluritechnologiques, génie civil, construction, bois",3,0.01007455168245013,0.0
+Bâtiment: construction et couverture,Spécialités plurivalentes de la communication,3,0.01007455168245013,79.0
+Journalisme et communication,"Sécurité des biens et des personnes, police, surveillance",3,0.01007455168245013,738.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Langues vivantes, civilisations étrangères et régionales",3,0.01007455168245013,0.0
+Autres...,Structures métalliques,3,0.01007455168245013,157.0
+"Forêts, espaces naturels, faune sauvage, pêche","Ressources humaines, gestion du personnel, gestion de l'emploi",3,0.01007455168245013,0.0
+"Spécialités pluritechnologiques, matériaux souples","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+Chimie,"Productions végétales,cultures spécialisées",3,0.01007455168245013,492.5
+Spécialités plurivalentes sanitaires et sociales,"Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,397.0
+Bâtiment: finitions,Spécialités plurivalentes sanitaires et sociales,3,0.01007455168245013,70.0
+"Matériaux de construction, verre, céramique","Ressources humaines, gestion du personnel, gestion de l'emploi",3,0.01007455168245013,324.0
+"Papier, carton",Spécialités pluritechnologiques des transformations,3,0.01007455168245013,315.0
+Moteurs et mécanique auto,Technologies de commandes des transformations industrielles,3,0.01007455168245013,403.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Productions végétales,cultures spécialisées",3,0.01007455168245013,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes de l'agronomie et de l'agriculture,3,0.01007455168245013,0.0
+"Energie, génie climatique","Français, littérature et civilisation françaises",3,0.01007455168245013,0.0
+Arts plastiques,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",3,0.01007455168245013,0.0
+Bâtiment: finitions,"Techniques de l'image et du son, métiers connexes du spectacle",3,0.01007455168245013,0.0
+Linguistique,"Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+Spécialités plurivalentes de la communication,Technologies de commandes des transformations industrielles,3,0.01007455168245013,0.0
+"Comptabilité, gestion","Spécialités plutitechnologiques, mécanique-électricité",3,0.01007455168245013,0.0
+"Electricité, électronique (non compris automatisme et productique)","Productions végétales,cultures spécialisées",3,0.01007455168245013,0.0
+"Aménagement du territoire, développement, urbanisme",Travail social,3,0.01007455168245013,0.0
+"Mines et carrières, génie civil, topographie",Moteurs et mécanique auto,3,0.01007455168245013,0.0
+"Energie, génie climatique",Travail du bois et de l'ameublement,3,0.01007455168245013,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Productions animales, élevage spécialisé, aquaculture, ...",3,0.01007455168245013,0.0
+"Matériaux de construction, verre, céramique",Travail du bois et de l'ameublement,3,0.01007455168245013,0.0
+"Chimie-biologie, biochimie","Productions animales, élevage spécialisé, aquaculture, ...",3,0.01007455168245013,0.0
+Bâtiment: construction et couverture,"Habillement (y compris mode, couture)",3,0.01007455168245013,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+"Habillement (y compris mode, couture)","Langues vivantes, civilisations étrangères et régionales",3,0.01007455168245013,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités pluriscientifiques,3,0.01007455168245013,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités plurivalentes des services,3,0.01007455168245013,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+Spécialités littéraires et artistiques plurivalentes,Technologies industrielles fondamentales,3,0.01007455168245013,0.0
+"Animation culturelle, sportive et de loisirs",Protection et développement du patrimoine,2,0.0067163677883000875,0.0
+"Français, littérature et civilisation françaises","Nettoyage, assainissement, protection de l'environnement",2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+Technologies de commandes des transformations industrielles,Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Musique, arts du spectacle",Psychologie,2,0.0067163677883000875,0.0
+"Musique, arts du spectacle","Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,0.0
+Spécialités concernant plusieurs capacités,"Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+Economie,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+Arts plastiques,"Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Développement des capacités comportementales et relationnelles,Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+Géographie,Physique-chimie,2,0.0067163677883000875,0.0
+Mécanique aéronautique et spatiale,Spécialités pluriscientifiques,2,0.0067163677883000875,0.0
+Développement des capacités individuelles d'organisation,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Spécialités littéraires et artistiques plurivalentes,Travail social,2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Vie familiale, vie sociale et autres formations au développement personnel",2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)","Musique, arts du spectacle",2,0.0067163677883000875,5.0
+"Forêts, espaces naturels, faune sauvage, pêche",Sciences de la terre,2,0.0067163677883000875,0.0
+Economie,"Musique, arts du spectacle",2,0.0067163677883000875,0.0
+"Musique, arts du spectacle",Pratiques sportives,2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)",Travail social,2,0.0067163677883000875,59.0
+"Accueil, hôtellerie, tourisme",Mécanique aéronautique et spatiale,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données",Développement des capacités individuelles d'organisation,2,0.0067163677883000875,86.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données",Spécialités plurivalentes des services,2,0.0067163677883000875,0.0
+Structures métalliques,"Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+Economie,Sciences de la vie,2,0.0067163677883000875,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Commerce, vente",Géographie,2,0.0067163677883000875,0.0
+Economie,"Forêts, espaces naturels, faune sauvage, pêche",2,0.0067163677883000875,0.0
+Autres...,"Matériaux de construction, verre, céramique",2,0.0067163677883000875,42.0
+Autres...,"Papier, carton",2,0.0067163677883000875,0.0
+Développement des capacités mentales et apprentissages de base,Spécialités militaires,2,0.0067163677883000875,0.0
+"Finances, banque, assurances",Géographie,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie",Sciences de la terre,2,0.0067163677883000875,59.0
+Bâtiment: construction et couverture,Sciences de la terre,2,0.0067163677883000875,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois","Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+Application des droits et statuts des personnes,"Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+Chimie,Physique,2,0.0067163677883000875,0.0
+Arts plastiques,"Comptabilité, gestion",2,0.0067163677883000875,0.0
+"Langues vivantes, civilisations étrangères et régionales","Nettoyage, assainissement, protection de l'environnement",2,0.0067163677883000875,264.0
+"Comptabilité, gestion",Economie et activités domestiques,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données","Finances, banque, assurances",2,0.0067163677883000875,0.0
+Spécialités littéraires et artistiques plurivalentes,"Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+"Finances, banque, assurances",Protection et développement du patrimoine,2,0.0067163677883000875,408.0
+"Forêts, espaces naturels, faune sauvage, pêche",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Mécanique aéronautique et spatiale,"Plasturgie, matériaux composites",2,0.0067163677883000875,0.0
+"Plasturgie, matériaux composites","Secrétariat, bureautique",2,0.0067163677883000875,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,0.0
+Spécialités pluriscientifiques,"Vie familiale, vie sociale et autres formations au développement personnel",2,0.0067163677883000875,0.0
+"Chimie-biologie, biochimie","Coiffure, esthétique et autres spécialités des services aux personnes",2,0.0067163677883000875,0.0
+"Droit, sciences politiques",Pratiques sportives,2,0.0067163677883000875,0.0
+Développement des capacités mentales et apprentissages de base,"Energie, génie climatique",2,0.0067163677883000875,0.0
+"Techniques de l'image et du son, métiers connexes du spectacle",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Commerce, vente","Philosophie, éthique et théologie",2,0.0067163677883000875,32.0
+"Enseignement, formation",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Histoire,"Langues vivantes, civilisations étrangères et régionales",2,0.0067163677883000875,0.0
+Journalisme et communication,Protection et développement du patrimoine,2,0.0067163677883000875,13.0
+Economie,"Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Bâtiment: construction et couverture,Protection et développement du patrimoine,2,0.0067163677883000875,0.0
+"Productions végétales,cultures spécialisées",Sciences de la vie,2,0.0067163677883000875,0.0
+Journalisme et communication,"Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Physique,Sciences de la vie,2,0.0067163677883000875,0.0
+Santé,Sciences de la terre,2,0.0067163677883000875,0.0
+"Comptabilité, gestion",Sciences naturelles (Biologie-Géologie),2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)",Linguistique,2,0.0067163677883000875,90.0
+Jeux et activités spécifiques de loisirs,"Langues vivantes, civilisations étrangères et régionales",2,0.0067163677883000875,0.0
+"Productions végétales,cultures spécialisées",Technologies industrielles fondamentales,2,0.0067163677883000875,0.0
+"Accueil, hôtellerie, tourisme",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Nettoyage, assainissement, protection de l'environnement",Pratiques sportives,2,0.0067163677883000875,0.0
+Langues et civilisations anciennes,"Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,0.0
+"Français, littérature et civilisation françaises",Physique-chimie,2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)",Travail social,2,0.0067163677883000875,0.0
+Spécialités pluritechnologiques des transformations,Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)","Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Sciences de la vie,2,0.0067163677883000875,28.0
+"Philosophie, éthique et théologie",Spécialités plurivalentes de la communication,2,0.0067163677883000875,0.0
+"Droit, sciences politiques",Développement des capacités mentales et apprentissages de base,2,0.0067163677883000875,0.0
+"Aménagement du territoire, développement, urbanisme",Application des droits et statuts des personnes,2,0.0067163677883000875,0.0
+Psychologie,Sciences naturelles (Biologie-Géologie),2,0.0067163677883000875,0.0
+"Langues vivantes, civilisations étrangères et régionales",Sciences de la vie,2,0.0067163677883000875,0.0
+Spécialités littéraires et artistiques plurivalentes,"Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+Spécialités concernant plusieurs capacités,Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Physique-chimie,"Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+Mécanique aéronautique et spatiale,Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+Chimie,Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,0.0
+Physique-chimie,"Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,0.0
+"Animation culturelle, sportive et de loisirs",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Jeux et activités spécifiques de loisirs,"Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+"Matériaux de construction, verre, céramique",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Protection et développement du patrimoine,Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,0.0
+"Energie, génie climatique",Protection et développement du patrimoine,2,0.0067163677883000875,0.0
+"Mathématiques, statistiques",Sciences de la terre,2,0.0067163677883000875,0.0
+"Aménagement du territoire, développement, urbanisme","Productions végétales,cultures spécialisées",2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Musique, arts du spectacle",2,0.0067163677883000875,0.0
+"Mathématiques, statistiques",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Développement des capacités individuelles d'organisation,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+"Energie, génie climatique","Musique, arts du spectacle",2,0.0067163677883000875,0.0
+Physique,Technologies industrielles fondamentales,2,0.0067163677883000875,0.0
+"Langues vivantes, civilisations étrangères et régionales",Physique,2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,0.0
+Bâtiment: construction et couverture,Techniques de l'imprimerie et de l'édition,2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine","Musique, arts du spectacle",2,0.0067163677883000875,0.0
+"Enseignement, formation",Physique,2,0.0067163677883000875,0.0
+"Mécanique générale et de précision, usinage",Sciences de la terre,2,0.0067163677883000875,126.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Mathématiques, statistiques",2,0.0067163677883000875,0.0
+"Energie, génie climatique","Plasturgie, matériaux composites",2,0.0067163677883000875,0.0
+"Animation culturelle, sportive et de loisirs",Economie,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie","Nettoyage, assainissement, protection de l'environnement",2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+Linguistique,"Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Sciences naturelles (Biologie-Géologie),2,0.0067163677883000875,0.0
+"Animation culturelle, sportive et de loisirs",Sciences de la terre,2,0.0067163677883000875,0.0
+Chimie,Physique-chimie,2,0.0067163677883000875,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Langues et civilisations anciennes,2,0.0067163677883000875,26.0
+"Mathématiques, statistiques","Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Histoire,Physique-chimie,2,0.0067163677883000875,0.0
+Journalisme et communication,"Nettoyage, assainissement, protection de l'environnement",2,0.0067163677883000875,18.0
+Economie,"Vie familiale, vie sociale et autres formations au développement personnel",2,0.0067163677883000875,0.0
+"Finances, banque, assurances","Vie familiale, vie sociale et autres formations au développement personnel",2,0.0067163677883000875,0.0
+"Aménagement du territoire, développement, urbanisme",Journalisme et communication,2,0.0067163677883000875,0.0
+"Mécanique générale et de précision, usinage",Pratiques sportives,2,0.0067163677883000875,0.0
+"Energie, génie climatique",Journalisme et communication,2,0.0067163677883000875,85.0
+"Mécanique générale et de précision, usinage",Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,0.0
+Santé,Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,190.0
+Application des droits et statuts des personnes,Développement des capacités mentales et apprentissages de base,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données",Développement des capacités comportementales et relationnelles,2,0.0067163677883000875,0.0
+"Matériaux de construction, verre, céramique","Plasturgie, matériaux composites",2,0.0067163677883000875,0.0
+"Plasturgie, matériaux composites",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine","Mathématiques, statistiques",2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Finances, banque, assurances",2,0.0067163677883000875,364.0
+Cuirs et peaux,"Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,54.0
+"Mathématiques, statistiques",Structures métalliques,2,0.0067163677883000875,0.0
+Journalisme et communication,"Mathématiques, statistiques",2,0.0067163677883000875,0.0
+"Nettoyage, assainissement, protection de l'environnement","Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,121.0
+Développement des capacités comportementales et relationnelles,Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Energie, génie climatique",Mécanique aéronautique et spatiale,2,0.0067163677883000875,0.0
+Autres...,Physique-chimie,2,0.0067163677883000875,170.0
+Application des droits et statuts des personnes,"Finances, banque, assurances",2,0.0067163677883000875,511.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Spécialités plurivalentes des services,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Mécanique aéronautique et spatiale,Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+"Mathématiques, statistiques",Mécanique aéronautique et spatiale,2,0.0067163677883000875,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Arts plastiques,"Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités pluriscientifiques,2,0.0067163677883000875,0.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Structures métalliques,2,0.0067163677883000875,0.0
+"Musique, arts du spectacle","Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,0.0
+"Secrétariat, bureautique",Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+"Spécialités pluritechnologiques, matériaux souples","Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)","Informatique, traitement de l'information, réseaux de transmission des données",2,0.0067163677883000875,0.0
+Spécialités pluritechnologiques des transformations,"Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,50.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Aménagement du territoire, développement, urbanisme","Documentation, bibliothèques, administration des données",2,0.0067163677883000875,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Histoire,2,0.0067163677883000875,0.0
+Langues et civilisations anciennes,Spécialités plurivalentes de la communication,2,0.0067163677883000875,0.0
+Arts plastiques,Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,0.0
+Histoire,Santé,2,0.0067163677883000875,151.0
+"Productions végétales,cultures spécialisées","Secrétariat, bureautique",2,0.0067163677883000875,0.0
+Structures métalliques,"Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,0.0
+Sciences de la vie,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,51.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi",Sciences de la terre,2,0.0067163677883000875,0.0
+Chimie,"Nettoyage, assainissement, protection de l'environnement",2,0.0067163677883000875,0.0
+"Finances, banque, assurances",Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+Sciences naturelles (Biologie-Géologie),Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,189.0
+Géographie,Santé,2,0.0067163677883000875,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,43.0
+"Français, littérature et civilisation françaises",Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie",Physique,2,0.0067163677883000875,0.0
+"Secrétariat, bureautique",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+Développement des capacités mentales et apprentissages de base,"Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+"Mathématiques, statistiques","Mines et carrières, génie civil, topographie",2,0.0067163677883000875,0.0
+"Spécialités pluritechnologiques, matériaux souples",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Bâtiment: construction et couverture,Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Philosophie, éthique et théologie",Spécialités pluriscientifiques,2,0.0067163677883000875,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Physique,2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)","Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,0.0
+Développement des capacités comportementales et relationnelles,Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,76.0
+"Chimie-biologie, biochimie","Transport, manutention, magasinage",2,0.0067163677883000875,0.0
+"Mécanique générale et de précision, usinage",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,156.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,0.0
+Physique,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Mécanique générale et de précision, usinage",Textile,2,0.0067163677883000875,34.0
+Economie,"Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,0.0
+Arts plastiques,"Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+"Finances, banque, assurances","Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+Techniques de l'imprimerie et de l'édition,"Transport, manutention, magasinage",2,0.0067163677883000875,0.0
+"Sciences sociales (y compris démographie, anthropologie)","Secrétariat, bureautique",2,0.0067163677883000875,88.0
+"Mines et carrières, génie civil, topographie",Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)","Forêts, espaces naturels, faune sauvage, pêche",2,0.0067163677883000875,315.0
+"Energie, génie climatique",Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+"Comptabilité, gestion",Physique-chimie,2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)",Techniques de l'imprimerie et de l'édition,2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine",Spécialités littéraires et artistiques plurivalentes,2,0.0067163677883000875,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+Santé,Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+"Secrétariat, bureautique",Structures métalliques,2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+Autres...,Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Finances, banque, assurances",Techniques de l'imprimerie et de l'édition,2,0.0067163677883000875,15.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Accueil, hôtellerie, tourisme","Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Travail du bois et de l'ameublement,2,0.0067163677883000875,77.0
+Application des droits et statuts des personnes,Spécialités plurivalentes de la communication,2,0.0067163677883000875,19.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Protection et développement du patrimoine,2,0.0067163677883000875,40.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Spécialités concernant plusieurs capacités,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+"Accueil, hôtellerie, tourisme",Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+"Plasturgie, matériaux composites",Travail du bois et de l'ameublement,2,0.0067163677883000875,132.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Electricité, électronique (non compris automatisme et productique)",2,0.0067163677883000875,19.0
+Développement des capacités comportementales et relationnelles,"Habillement (y compris mode, couture)",2,0.0067163677883000875,43.5
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,328.5
+"Forêts, espaces naturels, faune sauvage, pêche","Secrétariat, bureautique",2,0.0067163677883000875,17.0
+"Accueil, hôtellerie, tourisme","Forêts, espaces naturels, faune sauvage, pêche",2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Français, littérature et civilisation françaises",2,0.0067163677883000875,35.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Travail du bois et de l'ameublement,2,0.0067163677883000875,29.5
+"Coiffure, esthétique et autres spécialités des services aux personnes","Droit, sciences politiques",2,0.0067163677883000875,425.0
+Arts plastiques,"Coiffure, esthétique et autres spécialités des services aux personnes",2,0.0067163677883000875,1564.0
+"Comptabilité, gestion",Sciences de la vie,2,0.0067163677883000875,156.0
+"Papier, carton","Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,207.0
+"Musique, arts du spectacle",Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,46.0
+"Secrétariat, bureautique",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,202.0
+"Electricité, électronique (non compris automatisme et productique)","Musique, arts du spectacle",2,0.0067163677883000875,17.0
+"Chimie-biologie, biochimie",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Philosophie, éthique et théologie",Sciences naturelles (Biologie-Géologie),2,0.0067163677883000875,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,14.0
+Spécialités plurivalentes des échanges et de la gestion,Travail du bois et de l'ameublement,2,0.0067163677883000875,213.0
+"Finances, banque, assurances",Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,103.0
+"Enseignement, formation","Productions végétales,cultures spécialisées",2,0.0067163677883000875,0.0
+Développement des capacités individuelles d'organisation,"Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,256.0
+"Français, littérature et civilisation françaises","Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,18.0
+Spécialités pluriscientifiques,"Techniques de l'image et du son, métiers connexes du spectacle",2,0.0067163677883000875,0.0
+Chimie,"Droit, sciences politiques",2,0.0067163677883000875,27.0
+"Habillement (y compris mode, couture)",Santé,2,0.0067163677883000875,77.0
+"Documentation, bibliothèques, administration des données",Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,477.5
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Productions végétales,cultures spécialisées",2,0.0067163677883000875,131.0
+Bâtiment: finitions,"Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,93.0
+Bâtiment: finitions,"Coiffure, esthétique et autres spécialités des services aux personnes",2,0.0067163677883000875,37.0
+Autres...,Cuirs et peaux,2,0.0067163677883000875,86.5
+"Comptabilité, gestion","Mécanique générale et de précision, usinage",2,0.0067163677883000875,141.5
+Spécialités littéraires et artistiques plurivalentes,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine","Mines et carrières, génie civil, topographie",2,0.0067163677883000875,301.0
+"Mines et carrières, génie civil, topographie",Spécialités plurivalentes des services,2,0.0067163677883000875,301.0
+"Langues vivantes, civilisations étrangères et régionales",Textile,2,0.0067163677883000875,105.0
+"Productions végétales,cultures spécialisées",Spécialités plurivalentes des services,2,0.0067163677883000875,99.0
+Bâtiment: finitions,Structures métalliques,2,0.0067163677883000875,0.0
+Jeux et activités spécifiques de loisirs,"Sécurité des biens et des personnes, police, surveillance",2,0.0067163677883000875,247.0
+"Comptabilité, gestion",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,0.0
+"Transport, manutention, magasinage",Travail du bois et de l'ameublement,2,0.0067163677883000875,2195.0
+"Energie, génie climatique",Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,112.0
+Bâtiment: construction et couverture,Travail social,2,0.0067163677883000875,61.0
+"Plasturgie, matériaux composites","Transport, manutention, magasinage",2,0.0067163677883000875,443.0
+Développement des capacités individuelles d'organisation,"Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités concernant plusieurs capacités,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données","Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,86.0
+Cuirs et peaux,Structures métalliques,2,0.0067163677883000875,360.0
+"Sciences sociales (y compris démographie, anthropologie)",Technologies industrielles fondamentales,2,0.0067163677883000875,1002.0
+"Mines et carrières, génie civil, topographie",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Travail social,2,0.0067163677883000875,198.0
+Spécialités plurivalentes des services à la collectivité,Travail social,2,0.0067163677883000875,198.0
+"Droit, sciences politiques","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",2,0.0067163677883000875,68.0
+"Agro-alimentaire, alimentation, cuisine","Papier, carton",2,0.0067163677883000875,315.0
+"Musique, arts du spectacle","Transport, manutention, magasinage",2,0.0067163677883000875,359.0
+"Nettoyage, assainissement, protection de l'environnement","Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,801.0
+"Musique, arts du spectacle",Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,134.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Spécialités plurivalentes des services à la collectivité,2,0.0067163677883000875,862.0
+"Productions végétales,cultures spécialisées",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,96.0
+"Electricité, électronique (non compris automatisme et productique)",Textile,2,0.0067163677883000875,357.5
+Textile,"Transport, manutention, magasinage",2,0.0067163677883000875,478.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,109.0
+Sciences naturelles (Biologie-Géologie),"Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,109.0
+"Documentation, bibliothèques, administration des données","Spécialités pluridisciplinaires, sciences humaines et droit",2,0.0067163677883000875,211.0
+"Habillement (y compris mode, couture)",Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,28.0
+"Secrétariat, bureautique",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+Application des droits et statuts des personnes,"Vie familiale, vie sociale et autres formations au développement personnel",2,0.0067163677883000875,52.0
+Mécanique aéronautique et spatiale,Spécialités militaires,2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)",Psychologie,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie",Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,0.0
+Spécialités plurivalentes des échanges et de la gestion,Structures métalliques,2,0.0067163677883000875,0.0
+Cuirs et peaux,Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Structures métalliques,2,0.0067163677883000875,0.0
+"Mécanique générale et de précision, usinage",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Habillement (y compris mode, couture)",2,0.0067163677883000875,0.0
+"Productions végétales,cultures spécialisées","Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+Chimie,"Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,0.0
+Bâtiment: finitions,Techniques de l'imprimerie et de l'édition,2,0.0067163677883000875,0.0
+Chimie,"Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,0.0
+"Plasturgie, matériaux composites","Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Forêts, espaces naturels, faune sauvage, pêche",2,0.0067163677883000875,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,0.0
+Spécialités concernant plusieurs capacités,"Transport, manutention, magasinage",2,0.0067163677883000875,0.0
+"Matériaux de construction, verre, céramique","Transport, manutention, magasinage",2,0.0067163677883000875,0.0
+"Musique, arts du spectacle",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Droit, sciences politiques",2,0.0067163677883000875,0.0
+"Français, littérature et civilisation françaises","Habillement (y compris mode, couture)",2,0.0067163677883000875,0.0
+Linguistique,Textile,2,0.0067163677883000875,0.0
+Journalisme et communication,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+"Droit, sciences politiques",Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+Moteurs et mécanique auto,"Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+Bâtiment: construction et couverture,"Coiffure, esthétique et autres spécialités des services aux personnes",2,0.0067163677883000875,0.0
+"Habillement (y compris mode, couture)",Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie","Ressources humaines, gestion du personnel, gestion de l'emploi",2,0.0067163677883000875,0.0
+"Aménagement du territoire, développement, urbanisme","Matériaux de construction, verre, céramique",2,0.0067163677883000875,0.0
+"Français, littérature et civilisation françaises","Mécanique générale et de précision, usinage",2,0.0067163677883000875,0.0
+"Droit, sciences politiques","Mines et carrières, génie civil, topographie",2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie",Spécialités pluriscientifiques,2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine","Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+"Langues vivantes, civilisations étrangères et régionales","Spécialités pluritechnologiques, matériaux souples",2,0.0067163677883000875,0.0
+Psychologie,"Transport, manutention, magasinage",2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Productions végétales,cultures spécialisées",2,0.0067163677883000875,0.0
+"Langues vivantes, civilisations étrangères et régionales","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",2,0.0067163677883000875,0.0
+"Matériaux de construction, verre, céramique","Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,0.0
+Bâtiment: finitions,Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+Chimie,Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+"Accueil, hôtellerie, tourisme","Droit, sciences politiques",2,0.0067163677883000875,0.0
+"Agro-alimentaire, alimentation, cuisine",Cuirs et peaux,2,0.0067163677883000875,0.0
+"Mines et carrières, génie civil, topographie",Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données",Travail social,2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)","Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+Cuirs et peaux,"Spécialités pluritechnologiques, génie civil, construction, bois",2,0.0067163677883000875,0.0
+"Electricité, électronique (non compris automatisme et productique)",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Transformations chimiques et apparentées (y compris pharmaceutiques),2,0.0067163677883000875,0.0
+Bâtiment: finitions,"Productions animales, élevage spécialisé, aquaculture, ...",2,0.0067163677883000875,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Moteurs et mécanique auto,2,0.0067163677883000875,0.0
+Psychologie,Spécialités plurivalentes de l'agronomie et de l'agriculture,2,0.0067163677883000875,0.0
+Chimie,"Mécanique générale et de précision, usinage",2,0.0067163677883000875,0.0
+"Musique, arts du spectacle",Technologies industrielles fondamentales,2,0.0067163677883000875,0.0
+Bâtiment: finitions,Journalisme et communication,2,0.0067163677883000875,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités plurivalentes de la communication,2,0.0067163677883000875,0.0
+Pratiques sportives,Spécialités plurivalentes sanitaires et sociales,2,0.0067163677883000875,0.0
+"Chimie-biologie, biochimie",Psychologie,2,0.0067163677883000875,0.0
+"Matériaux de construction, verre, céramique",Spécialités plurivalentes des échanges et de la gestion,2,0.0067163677883000875,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Droit, sciences politiques",2,0.0067163677883000875,0.0
+Technologies industrielles fondamentales,Travail du bois et de l'ameublement,2,0.0067163677883000875,0.0
+Langues et civilisations anciennes,Spécialités plurivalentes des services,2,0.0067163677883000875,0.0
+"Chimie-biologie, biochimie","Finances, banque, assurances",2,0.0067163677883000875,0.0
+Histoire,Psychologie,2,0.0067163677883000875,0.0
+"Commerce, vente","Papier, carton",2,0.0067163677883000875,0.0
+"Droit, sciences politiques","Productions végétales,cultures spécialisées",2,0.0067163677883000875,0.0
+Structures métalliques,Technologies de commandes des transformations industrielles,2,0.0067163677883000875,0.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités pluritechnologiques des transformations,2,0.0067163677883000875,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Spécialités plutitechnologiques, mécanique-électricité",2,0.0067163677883000875,0.0
+"Chimie-biologie, biochimie","Philosophie, éthique et théologie",2,0.0067163677883000875,0.0
+Sciences naturelles (Biologie-Géologie),"Sciences sociales (y compris démographie, anthropologie)",2,0.0067163677883000875,0.0
+Chimie,Economie,2,0.0067163677883000875,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Informatique, traitement de l'information, réseaux de transmission des données",2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données","Langues vivantes, civilisations étrangères et régionales",2,0.0067163677883000875,0.0
+"Documentation, bibliothèques, administration des données","Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,0.0
+"Energie, génie climatique",Travail social,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Economie et activités domestiques,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+Linguistique,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Spécialités plurivalentes des services,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Techniques de l'image et du son, métiers connexes du spectacle",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,Psychologie,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+"Musique, arts du spectacle","Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+Economie,Economie et activités domestiques,1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,"Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+Sciences de la vie,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Physique,1,0.0033581838941500438,0.0
+Protection et développement du patrimoine,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Energie, génie climatique","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Techniques de l'imprimerie et de l'édition,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Physique-chimie,1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,"Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Textile,1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,"Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+Histoire,Travail social,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+Formations générales,Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Développement des capacités individuelles d'organisation,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Productions végétales,cultures spécialisées",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme",Arts plastiques,1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine",Géographie,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Spécialités militaires,1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites",Santé,1,0.0033581838941500438,0.0
+Géographie,"Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,0.0
+Economie,"Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+Economie,Textile,1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Documentation, bibliothèques, administration des données",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique","Papier, carton",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Moteurs et mécanique auto,1,0.0033581838941500438,0.0
+Physique-chimie,"Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Finances, banque, assurances",Sciences de la terre,1,0.0033581838941500438,0.0
+Géographie,Sciences de la terre,1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Formations générales,"Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,"Musique, arts du spectacle",1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)",Histoire,1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+"Enseignement, formation","Plasturgie, matériaux composites",1,0.0033581838941500438,0.0
+Développement des capacités comportementales et relationnelles,Textile,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Economie et activités domestiques,"Enseignement, formation",1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,"Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Sciences naturelles (Biologie-Géologie),"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Sciences de la terre,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Economie,1,0.0033581838941500438,0.0
+Histoire,"Informatique, traitement de l'information, réseaux de transmission des données",1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,Autres...,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Sciences de la vie,1,0.0033581838941500438,0.0
+"Commerce, vente",Economie et activités domestiques,1,0.0033581838941500438,0.0
+"Langues vivantes, civilisations étrangères et régionales",Physique-chimie,1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Journalisme et communication,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Spécialités pluritechnologiques, matériaux souples",Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+Géographie,"Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Economie,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Cuirs et peaux,Linguistique,1,0.0033581838941500438,0.0
+"Comptabilité, gestion",Géographie,1,0.0033581838941500438,0.0
+Sciences de la vie,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Psychologie,1,0.0033581838941500438,0.0
+Sciences de la vie,Travail social,1,0.0033581838941500438,0.0
+"Papier, carton","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,Travail social,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Arts plastiques,Cuirs et peaux,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Textile,1,0.0033581838941500438,0.0
+Economie et activités domestiques,"Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Histoire,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Histoire,1,0.0033581838941500438,0.0
+Histoire,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Géographie,"Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Géographie,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+Arts plastiques,Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+Sciences de la vie,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Economie,"Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Physique-chimie,1,0.0033581838941500438,0.0
+"Energie, génie climatique","Mathématiques, statistiques",1,0.0033581838941500438,0.0
+Protection et développement du patrimoine,Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement","Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Finances, banque, assurances",Sciences de la vie,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement",Physique-chimie,1,0.0033581838941500438,0.0
+Autres...,Histoire,1,0.0033581838941500438,0.0
+"Langues vivantes, civilisations étrangères et régionales",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Economie,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Géographie,Journalisme et communication,1,0.0033581838941500438,0.0
+Géographie,"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Sciences de la vie,1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Energie, génie climatique",Pratiques sportives,1,0.0033581838941500438,0.0
+"Enseignement, formation",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+Sciences naturelles (Biologie-Géologie),Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Energie, génie climatique",Sciences de la vie,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Géographie,1,0.0033581838941500438,0.0
+Géographie,"Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+Economie,Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Technologies industrielles fondamentales,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Jeux et activités spécifiques de loisirs,1,0.0033581838941500438,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités militaires,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Sciences de la terre,1,0.0033581838941500438,0.0
+Physique-chimie,Pratiques sportives,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Physique-chimie,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+"Mathématiques, statistiques","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+Arts plastiques,"Plasturgie, matériaux composites",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+Arts plastiques,"Mathématiques, statistiques",1,0.0033581838941500438,0.0
+Arts plastiques,Physique,1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Physique,1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Physique,1,0.0033581838941500438,0.0
+Economie,Physique-chimie,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme",Autres disciplines artistiques et spécialités artistiques plurivalentes,1,0.0033581838941500438,0.0
+"Finances, banque, assurances",Pratiques sportives,1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Physique,1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique",Psychologie,1,0.0033581838941500438,0.0
+Arts plastiques,Economie,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)",Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+Arts plastiques,"Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Technologies industrielles fondamentales,"Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Physique-chimie,1,0.0033581838941500438,0.0
+Techniques de l'imprimerie et de l'édition,Textile,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,0.0
+Développement des capacités comportementales et relationnelles,Physique,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Physique,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Linguistique,Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+"Mathématiques, statistiques",Moteurs et mécanique auto,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Sciences de la vie,1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,"Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,0.0
+"Enseignement, formation","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Structures métalliques,1,0.0033581838941500438,0.0
+Economie,"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Spécialités pluriscientifiques,"Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+Bâtiment: finitions,Economie,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement",Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+"Enseignement, formation",Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Chimie,Santé,1,0.0033581838941500438,0.0
+"Energie, génie climatique","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,Linguistique,1,0.0033581838941500438,0.0
+Bâtiment: finitions,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+Spécialités concernant plusieurs capacités,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,"Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Bâtiment: finitions,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Géographie,"Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Spécialités militaires,1,0.0033581838941500438,0.0
+Spécialités concernant plusieurs capacités,Spécialités militaires,1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,Pratiques sportives,1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,Sciences de la vie,1,0.0033581838941500438,0.0
+Sciences de la terre,"Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,Physique-chimie,1,0.0033581838941500438,0.0
+Chimie,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,0.0
+Formations générales,Spécialités militaires,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique",Travail social,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites","Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Structures métalliques,1,0.0033581838941500438,0.0
+Bâtiment: finitions,Développement des capacités individuelles d'organisation,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Jeux et activités spécifiques de loisirs,1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique",Textile,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)",Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine",Application des droits et statuts des personnes,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,"Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Géographie,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+Journalisme et communication,Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Chimie-biologie, biochimie",1,0.0033581838941500438,0.0
+Santé,"Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme","Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Français, littérature et civilisation françaises",1,0.0033581838941500438,0.0
+Géographie,Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Economie,1,0.0033581838941500438,0.0
+"Sciences sociales (y compris démographie, anthropologie)",Textile,1,0.0033581838941500438,0.0
+"Français, littérature et civilisation françaises",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Jeux et activités spécifiques de loisirs,1,0.0033581838941500438,0.0
+Economie et activités domestiques,"Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+Economie,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Textile,1,0.0033581838941500438,0.0
+Pratiques sportives,"Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Français, littérature et civilisation françaises",1,0.0033581838941500438,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+Histoire,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Histoire,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+Histoire,Textile,1,0.0033581838941500438,0.0
+Spécialités plurivalentes des services,"Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Sciences de la vie,1,0.0033581838941500438,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+Spécialités littéraires et artistiques plurivalentes,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Chimie,"Informatique, traitement de l'information, réseaux de transmission des données",1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Economie,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Comptabilité, gestion",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Energie, génie climatique",1,0.0033581838941500438,0.0
+"Finances, banque, assurances",Histoire,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+Pratiques sportives,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Mathématiques, statistiques",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Linguistique,"Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Mathématiques, statistiques","Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+Histoire,Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Commerce, vente",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Sciences naturelles (Biologie-Géologie),Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Formations générales,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Pratiques sportives,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Papier, carton",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Bâtiment: finitions,Psychologie,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Textile,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Animation culturelle, sportive et de loisirs",1,0.0033581838941500438,0.0
+Arts plastiques,Développement des capacités individuelles d'organisation,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,"Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+Physique-chimie,"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+"Electricité, électronique (non compris automatisme et productique)","Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+Santé,Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Secrétariat, bureautique",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+Spécialités pluriscientifiques,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+Développement des capacités individuelles d'organisation,"Mathématiques, statistiques",1,0.0033581838941500438,0.0
+Jeux et activités spécifiques de loisirs,"Mathématiques, statistiques",1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine","Plasturgie, matériaux composites",1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Langues vivantes, civilisations étrangères et régionales",1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement",Psychologie,1,0.0033581838941500438,0.0
+Autres...,Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Sciences de la terre,"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,"Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+"Sécurité des biens et des personnes, police, surveillance",Textile,1,0.0033581838941500438,680.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,24.0
+"Spécialités pluridisciplinaires, sciences humaines et droit",Structures métalliques,1,0.0033581838941500438,29.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Habillement (y compris mode, couture)",1,0.0033581838941500438,160.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie","Productions végétales,cultures spécialisées",1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Histoire,1,0.0033581838941500438,9.0
+Histoire,"Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,9.0
+"Accueil, hôtellerie, tourisme","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,16.0
+Transformations chimiques et apparentées (y compris pharmaceutiques),"Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,13.0
+Spécialités concernant plusieurs capacités,Textile,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,315.0
+"Techniques de l'image et du son, métiers connexes du spectacle",Travail social,1,0.0033581838941500438,24.0
+Technologies industrielles fondamentales,Travail social,1,0.0033581838941500438,491.0
+"Matériaux de construction, verre, céramique","Secrétariat, bureautique",1,0.0033581838941500438,0.0
+Linguistique,Spécialités concernant plusieurs capacités,1,0.0033581838941500438,136.0
+Développement des capacités comportementales et relationnelles,Histoire,1,0.0033581838941500438,526.0
+Développement des capacités individuelles d'organisation,Histoire,1,0.0033581838941500438,526.0
+"Accueil, hôtellerie, tourisme","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,332.0
+"Habillement (y compris mode, couture)",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,73.0
+"Sécurité des biens et des personnes, police, surveillance",Travail du bois et de l'ameublement,1,0.0033581838941500438,94.0
+Spécialités militaires,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,255.0
+"Mines et carrières, génie civil, topographie",Mécanique aéronautique et spatiale,1,0.0033581838941500438,75.0
+Arts plastiques,Sciences de la terre,1,0.0033581838941500438,9.0
+"Droit, sciences politiques","Forêts, espaces naturels, faune sauvage, pêche",1,0.0033581838941500438,229.0
+"Techniques de l'image et du son, métiers connexes du spectacle",Travail du bois et de l'ameublement,1,0.0033581838941500438,66.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,326.0
+"Comptabilité, gestion","Papier, carton",1,0.0033581838941500438,207.0
+"Animation culturelle, sportive et de loisirs",Travail du bois et de l'ameublement,1,0.0033581838941500438,30.0
+Langues et civilisations anciennes,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,214.0
+Jeux et activités spécifiques de loisirs,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,195.0
+Sciences naturelles (Biologie-Géologie),"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,43.0
+"Energie, génie climatique",Géographie,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Application des droits et statuts des personnes,1,0.0033581838941500438,0.0
+Physique-chimie,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,85.0
+Santé,Textile,1,0.0033581838941500438,124.0
+"Papier, carton",Psychologie,1,0.0033581838941500438,103.0
+"Papier, carton",Textile,1,0.0033581838941500438,103.0
+Psychologie,Textile,1,0.0033581838941500438,103.0
+Bâtiment: construction et couverture,Journalisme et communication,1,0.0033581838941500438,29.0
+"Informatique, traitement de l'information, réseaux de transmission des données","Papier, carton",1,0.0033581838941500438,0.0
+Spécialités plurivalentes des échanges et de la gestion,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,81.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,81.0
+"Matériaux de construction, verre, céramique","Mines et carrières, génie civil, topographie",1,0.0033581838941500438,369.0
+"Accueil, hôtellerie, tourisme",Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+Protection et développement du patrimoine,Santé,1,0.0033581838941500438,50.0
+"Plasturgie, matériaux composites",Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+Spécialités plurivalentes sanitaires et sociales,Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+"Electricité, électronique (non compris automatisme et productique)",Journalisme et communication,1,0.0033581838941500438,112.0
+"Aménagement du territoire, développement, urbanisme","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,69.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,207.0
+"Forêts, espaces naturels, faune sauvage, pêche",Pratiques sportives,1,0.0033581838941500438,99.0
+"Aménagement du territoire, développement, urbanisme","Langues vivantes, civilisations étrangères et régionales",1,0.0033581838941500438,127.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,5.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Psychologie,1,0.0033581838941500438,723.0
+"Matériaux de construction, verre, céramique","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités plurivalentes de la communication,1,0.0033581838941500438,1033.0
+"Papier, carton","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme","Energie, génie climatique",1,0.0033581838941500438,577.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,131.0
+"Chimie-biologie, biochimie","Plasturgie, matériaux composites",1,0.0033581838941500438,42.0
+Jeux et activités spécifiques de loisirs,"Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,154.0
+"Mathématiques, statistiques",Textile,1,0.0033581838941500438,170.0
+"Nettoyage, assainissement, protection de l'environnement","Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,151.0
+Linguistique,Structures métalliques,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Psychologie,1,0.0033581838941500438,200.0
+"Chimie-biologie, biochimie","Comptabilité, gestion",1,0.0033581838941500438,164.0
+Chimie,Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,713.0
+"Agro-alimentaire, alimentation, cuisine",Jeux et activités spécifiques de loisirs,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Psychologie,1,0.0033581838941500438,81.0
+Bâtiment: construction et couverture,"Papier, carton",1,0.0033581838941500438,312.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Papier, carton",1,0.0033581838941500438,312.0
+Arts plastiques,Développement des capacités mentales et apprentissages de base,1,0.0033581838941500438,0.0
+Economie,Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Spécialités pluridisciplinaires, sciences humaines et droit","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,551.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Arts plastiques,1,0.0033581838941500438,278.0
+"Langues vivantes, civilisations étrangères et régionales",Protection et développement du patrimoine,1,0.0033581838941500438,0.0
+Arts plastiques,"Productions végétales,cultures spécialisées",1,0.0033581838941500438,202.0
+"Productions végétales,cultures spécialisées",Textile,1,0.0033581838941500438,202.0
+"Energie, génie climatique",Textile,1,0.0033581838941500438,105.0
+"Productions végétales,cultures spécialisées",Travail social,1,0.0033581838941500438,61.0
+Développement des capacités individuelles d'organisation,Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,51.0
+Développement des capacités individuelles d'organisation,Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,91.0
+"Spécialités pluritechnologiques, génie civil, construction, bois",Structures métalliques,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,250.0
+Bâtiment: finitions,Pratiques sportives,1,0.0033581838941500438,146.0
+Géographie,"Langues vivantes, civilisations étrangères et régionales",1,0.0033581838941500438,3248.0
+Géographie,Technologies industrielles fondamentales,1,0.0033581838941500438,3248.0
+"Electricité, électronique (non compris automatisme et productique)",Pratiques sportives,1,0.0033581838941500438,733.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Moteurs et mécanique auto,1,0.0033581838941500438,9.0
+Moteurs et mécanique auto,"Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,9.0
+"Comptabilité, gestion",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,21.0
+"Mines et carrières, génie civil, topographie",Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,112.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,115.0
+"Enseignement, formation",Histoire,1,0.0033581838941500438,151.0
+Mécanique aéronautique et spatiale,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,156.0
+"Philosophie, éthique et théologie","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,124.0
+"Français, littérature et civilisation françaises","Productions végétales,cultures spécialisées",1,0.0033581838941500438,504.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,140.0
+"Spécialités plutitechnologiques, mécanique-électricité",Travail du bois et de l'ameublement,1,0.0033581838941500438,47.0
+"Français, littérature et civilisation françaises","Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,109.0
+"Chimie-biologie, biochimie","Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,442.0
+Linguistique,Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,167.0
+"Commerce, vente",Structures métalliques,1,0.0033581838941500438,251.0
+"Français, littérature et civilisation françaises",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités pluriscientifiques,1,0.0033581838941500438,983.0
+Jeux et activités spécifiques de loisirs,"Transport, manutention, magasinage",1,0.0033581838941500438,341.0
+Physique-chimie,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,390.0
+"Matériaux de construction, verre, céramique",Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,99.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,99.0
+"Mécanique générale et de précision, usinage","Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,801.0
+Application des droits et statuts des personnes,"Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Sécurité des biens et des personnes, police, surveillance",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,642.0
+"Productions végétales,cultures spécialisées",Spécialités plurivalentes de la communication,1,0.0033581838941500438,539.0
+Linguistique,"Plasturgie, matériaux composites",1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,109.0
+"Agro-alimentaire, alimentation, cuisine",Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,46.0
+Développement des capacités comportementales et relationnelles,"Matériaux de construction, verre, céramique",1,0.0033581838941500438,124.0
+"Documentation, bibliothèques, administration des données",Sciences de la terre,1,0.0033581838941500438,211.0
+"Agro-alimentaire, alimentation, cuisine",Economie et activités domestiques,1,0.0033581838941500438,56.0
+Pratiques sportives,Travail social,1,0.0033581838941500438,717.0
+"Habillement (y compris mode, couture)",Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,28.0
+Bâtiment: finitions,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Cuirs et peaux,Moteurs et mécanique auto,1,0.0033581838941500438,570.0
+"Chimie-biologie, biochimie",Journalisme et communication,1,0.0033581838941500438,0.0
+Sciences de la terre,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites",Structures métalliques,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+Sciences de la vie,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Psychologie,1,0.0033581838941500438,0.0
+Sciences naturelles (Biologie-Géologie),Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Linguistique,Pratiques sportives,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Mécanique aéronautique et spatiale,1,0.0033581838941500438,0.0
+"Comptabilité, gestion",Mécanique aéronautique et spatiale,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Productions végétales,cultures spécialisées",Structures métalliques,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs",Structures métalliques,1,0.0033581838941500438,0.0
+Cuirs et peaux,Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+Cuirs et peaux,"Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Sciences de la terre,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie","Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+Chimie,"Commerce, vente",1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,Santé,1,0.0033581838941500438,0.0
+Chimie,Journalisme et communication,1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Textile,1,0.0033581838941500438,0.0
+Moteurs et mécanique auto,"Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+Chimie,"Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+Spécialités plurivalentes de la communication,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,"Vie familiale, vie sociale et autres formations au développement personnel",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique","Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Langues vivantes, civilisations étrangères et régionales",1,0.0033581838941500438,0.0
+Linguistique,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+Spécialités concernant plusieurs capacités,Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+"Energie, génie climatique",Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,"Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,0.0
+Pratiques sportives,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Coiffure, esthétique et autres spécialités des services aux personnes",Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Sciences de la terre,Structures métalliques,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine","Aménagement du territoire, développement, urbanisme",1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Papier, carton",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Jeux et activités spécifiques de loisirs,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Techniques de l'imprimerie et de l'édition,1,0.0033581838941500438,0.0
+Economie,Technologies industrielles fondamentales,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Energie, génie climatique",Psychologie,1,0.0033581838941500438,0.0
+Psychologie,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Langues vivantes, civilisations étrangères et régionales","Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Textile,1,0.0033581838941500438,0.0
+Cuirs et peaux,"Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+Protection et développement du patrimoine,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Psychologie,"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Développement des capacités comportementales et relationnelles,Economie et activités domestiques,1,0.0033581838941500438,0.0
+"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",Economie et activités domestiques,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+Linguistique,"Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+Développement des capacités comportementales et relationnelles,"Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie",Sciences de la terre,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+Bâtiment: finitions,"Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+"Energie, génie climatique","Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement","Papier, carton",1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Linguistique,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Sciences sociales (y compris démographie, anthropologie)","Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Chimie,1,0.0033581838941500438,0.0
+Moteurs et mécanique auto,"Nettoyage, assainissement, protection de l'environnement",1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Travail social,1,0.0033581838941500438,0.0
+Histoire,Sciences de la vie,1,0.0033581838941500438,0.0
+Cuirs et peaux,"Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Droit, sciences politiques","Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,"Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,0.0
+Développement des capacités mentales et apprentissages de base,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,0.0
+Arts plastiques,"Droit, sciences politiques",1,0.0033581838941500438,0.0
+Arts plastiques,Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+Spécialités plurivalentes des services,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Cuirs et peaux,Travail social,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme","Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,0.0
+"Papier, carton",Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+Arts plastiques,Sciences de la vie,1,0.0033581838941500438,0.0
+Arts plastiques,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+"Electricité, électronique (non compris automatisme et productique)","Habillement (y compris mode, couture)",1,0.0033581838941500438,0.0
+Technologies de commandes des transformations industrielles,Textile,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Economie,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+Linguistique,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+"Français, littérature et civilisation françaises",Moteurs et mécanique auto,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Sciences de la terre,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Bâtiment: construction et couverture,1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme","Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,0.0
+"Aménagement du territoire, développement, urbanisme",Santé,1,0.0033581838941500438,0.0
+"Comptabilité, gestion",Histoire,1,0.0033581838941500438,0.0
+Histoire,"Ressources humaines, gestion du personnel, gestion de l'emploi",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Physique,1,0.0033581838941500438,0.0
+Application des droits et statuts des personnes,"Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique",Santé,1,0.0033581838941500438,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,"Techniques de l'image et du son, métiers connexes du spectacle",1,0.0033581838941500438,0.0
+Spécialités militaires,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+"Ressources humaines, gestion du personnel, gestion de l'emploi","Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Spécialités littéraires et artistiques plurivalentes,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Moteurs et mécanique auto,Santé,1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+Géographie,Travail social,1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)","Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Finances, banque, assurances","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+Spécialités concernant plusieurs capacités,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Textile,1,0.0033581838941500438,0.0
+"Productions végétales,cultures spécialisées",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Arts plastiques,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",Travail social,1,0.0033581838941500438,0.0
+"Plasturgie, matériaux composites","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+Spécialités plurivalentes de l'agronomie et de l'agriculture,Travail social,1,0.0033581838941500438,0.0
+"Mathématiques, statistiques",Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+"Papier, carton",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Psychologie,1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Spécialités pluritechnologiques des transformations,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Sciences de la vie,Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+Arts plastiques,"Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+Transformations chimiques et apparentées (y compris pharmaceutiques),"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Mécanique générale et de précision, usinage",Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Histoire,1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données",Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+Histoire,Langues et civilisations anciennes,1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche",Linguistique,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)",Cuirs et peaux,1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+Chimie,Linguistique,1,0.0033581838941500438,0.0
+Psychologie,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+"Musique, arts du spectacle",Structures métalliques,1,0.0033581838941500438,0.0
+Structures métalliques,Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Productions végétales,cultures spécialisées",Spécialités concernant plusieurs capacités,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Textile,1,0.0033581838941500438,0.0
+Sciences de la vie,"Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Mathématiques, statistiques","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme",Economie,1,0.0033581838941500438,0.0
+"Comptabilité, gestion",Cuirs et peaux,1,0.0033581838941500438,0.0
+Cuirs et peaux,Technologies industrielles fondamentales,1,0.0033581838941500438,0.0
+Protection et développement du patrimoine,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Productions animales, élevage spécialisé, aquaculture, ...","Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Electricité, électronique (non compris automatisme et productique)",Spécialités littéraires et artistiques plurivalentes,1,0.0033581838941500438,0.0
+"Nettoyage, assainissement, protection de l'environnement",Spécialités pluritechnologiques des transformations,1,0.0033581838941500438,0.0
+"Langues vivantes, civilisations étrangères et régionales",Structures métalliques,1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+Formations générales,Géographie,1,0.0033581838941500438,0.0
+Géographie,Linguistique,1,0.0033581838941500438,0.0
+Bâtiment: finitions,Spécialités plurivalentes des services à la collectivité,1,0.0033581838941500438,0.0
+Bâtiment: construction et couverture,Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Chimie-biologie, biochimie",1,0.0033581838941500438,0.0
+Développement des capacités comportementales et relationnelles,Sciences naturelles (Biologie-Géologie),1,0.0033581838941500438,0.0
+"Secrétariat, bureautique",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+Bâtiment: finitions,"Papier, carton",1,0.0033581838941500438,0.0
+"Papier, carton",Technologies industrielles fondamentales,1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Spécialités plutitechnologiques, mécanique-électricité",1,0.0033581838941500438,0.0
+Transformations chimiques et apparentées (y compris pharmaceutiques),Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Informatique, traitement de l'information, réseaux de transmission des données",Spécialités militaires,1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine","Philosophie, éthique et théologie",1,0.0033581838941500438,0.0
+"Energie, génie climatique",Spécialités plurivalentes sanitaires et sociales,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,"Finances, banque, assurances",1,0.0033581838941500438,0.0
+"Français, littérature et civilisation françaises",Travail du bois et de l'ameublement,1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Documentation, bibliothèques, administration des données",1,0.0033581838941500438,0.0
+Spécialités militaires,Spécialités plurivalentes de la communication,1,0.0033581838941500438,0.0
+Spécialités militaires,Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Physique-chimie,1,0.0033581838941500438,0.0
+Spécialités pluriscientifiques,Structures métalliques,1,0.0033581838941500438,0.0
+Cuirs et peaux,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,0.0
+Cuirs et peaux,"Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,0.0
+Linguistique,"Spécialités pluritechnologiques, matériaux souples",1,0.0033581838941500438,0.0
+"Accueil, hôtellerie, tourisme","Electricité, électronique (non compris automatisme et productique)",1,0.0033581838941500438,0.0
+Linguistique,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Mines et carrières, génie civil, topographie",Structures métalliques,1,0.0033581838941500438,0.0
+"Comptabilité, gestion","Mines et carrières, génie civil, topographie",1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie","Productions animales, élevage spécialisé, aquaculture, ...",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique","Mécanique générale et de précision, usinage",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie",Economie,1,0.0033581838941500438,0.0
+"Aménagement paysager (parcs, jardins, espaces verts)","Musique, arts du spectacle",1,0.0033581838941500438,0.0
+"Philosophie, éthique et théologie","Sécurité des biens et des personnes, police, surveillance",1,0.0033581838941500438,0.0
+Langues et civilisations anciennes,"Transport, manutention, magasinage",1,0.0033581838941500438,0.0
+"Papier, carton","Secrétariat, bureautique",1,0.0033581838941500438,0.0
+"Documentation, bibliothèques, administration des données","Forêts, espaces naturels, faune sauvage, pêche",1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Droit, sciences politiques",Géographie,1,0.0033581838941500438,0.0
+Economie,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Sciences de la terre,Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+Sciences de la terre,Spécialités plurivalentes des services,1,0.0033581838941500438,0.0
+Chimie,"Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+"Matériaux de construction, verre, céramique",Spécialités pluriscientifiques,1,0.0033581838941500438,0.0
+"Habillement (y compris mode, couture)","Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+"Finances, banque, assurances",Transformations chimiques et apparentées (y compris pharmaceutiques),1,0.0033581838941500438,0.0
+"Animation culturelle, sportive et de loisirs","Français, littérature et civilisation françaises",1,0.0033581838941500438,0.0
+"Forêts, espaces naturels, faune sauvage, pêche","Langues vivantes, civilisations étrangères et régionales",1,0.0033581838941500438,0.0
+"Agro-alimentaire, alimentation, cuisine","Matériaux de construction, verre, céramique",1,0.0033581838941500438,0.0
+Chimie,Technologies de commandes des transformations industrielles,1,0.0033581838941500438,0.0
+Sciences de la terre,Spécialités plurivalentes de l'agronomie et de l'agriculture,1,0.0033581838941500438,0.0
+Moteurs et mécanique auto,"Spécialités pluritechnologiques, génie civil, construction, bois",1,0.0033581838941500438,0.0
+Journalisme et communication,Moteurs et mécanique auto,1,0.0033581838941500438,0.0
+Autres disciplines artistiques et spécialités artistiques plurivalentes,Physique-chimie,1,0.0033581838941500438,0.0
+Mécanique aéronautique et spatiale,Spécialités plurivalentes des échanges et de la gestion,1,0.0033581838941500438,0.0
+Physique,"Spécialités pluridisciplinaires, sciences humaines et droit",1,0.0033581838941500438,0.0
+"Chimie-biologie, biochimie","Sciences sociales (y compris démographie, anthropologie)",1,0.0033581838941500438,0.0
+Arts plastiques,Technologies industrielles fondamentales,1,0.0033581838941500438,0.0
+Moteurs et mécanique auto,"Métallurgie (y compris sidérurgie, fonderie, non ferreux...)",1,0.0033581838941500438,0.0
+"Commerce, vente",Mécanique aéronautique et spatiale,1,0.0033581838941500438,0.0

--- a/analyze_polyvalence.py
+++ b/analyze_polyvalence.py
@@ -1,0 +1,514 @@
+import csv
+import itertools
+import os
+from collections import Counter, defaultdict
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from analyze_specialites import (
+    REGION_NAMES,
+    Record,
+    format_float,
+    format_int,
+    load_records,
+    is_tam,
+)
+
+OUTPUT_DIR = "analysis_outputs"
+OUTPUT_MARKDOWN = os.path.join(OUTPUT_DIR, "polyvalence_analysis.md")
+OUTPUT_COMBOS_CSV = os.path.join(OUTPUT_DIR, "polyvalence_combinations.csv")
+
+
+def ensure_output_dir() -> None:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def count_specialites(record: Record) -> int:
+    return sum(1 for spec in record.specialites if spec is not None)
+
+
+def inclusive_counts(records: Iterable[Record]) -> Dict[int, int]:
+    counts = Counter()
+    for rec in records:
+        if rec.spec1 is None:
+            counts[0] += 1
+        if rec.spec1 is not None:
+            counts[1] += 1
+        if rec.spec2 is not None:
+            counts[2] += 1
+        if rec.spec3 is not None:
+            counts[3] += 1
+    return counts
+
+
+def exclusive_counts(records: Iterable[Record]) -> Counter:
+    counter: Counter = Counter()
+    for rec in records:
+        counter[count_specialites(rec)] += 1
+    return counter
+
+
+def average(values: List[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def compute_table1(records: List[Record], tam_records: List[Record]) -> Tuple[List[Dict[str, object]], List[Dict[str, object]]]:
+    total_base = len(records)
+    total_tam = len(tam_records)
+    inc_base = inclusive_counts(records)
+    inc_tam = inclusive_counts(tam_records)
+
+    rows: List[Dict[str, object]] = []
+    for key, label in [
+        (0, "0 (non renseigné)"),
+        (1, "1 seule"),
+        (2, "2 spécialités"),
+        (3, "3 spécialités"),
+    ]:
+        base_count = inc_base.get(key, 0)
+        tam_count = inc_tam.get(key, 0)
+        stag_values = [
+            rec.nb_stagiaires or 0.0
+            for rec in tam_records
+            if (
+                (key == 0 and rec.spec1 is None)
+                or (key == 1 and rec.spec1 is not None)
+                or (key == 2 and rec.spec2 is not None)
+                or (key == 3 and rec.spec3 is not None)
+            )
+        ]
+        rows.append(
+            {
+                "label": label,
+                "base_count": base_count,
+                "base_pct": (base_count / total_base * 100) if total_base else 0.0,
+                "tam_count": tam_count,
+                "tam_pct": (tam_count / total_tam * 100) if total_tam else 0.0,
+                "stag_mean": average(stag_values),
+            }
+        )
+
+    exc_counter = exclusive_counts(records)
+    exclusive_rows: List[Dict[str, object]] = []
+    for key, label in [
+        (0, "Non renseigné"),
+        (1, "Spécialisés"),
+        (2, "Diversifiés"),
+        (3, "Polyvalents"),
+    ]:
+        count = exc_counter.get(key, 0)
+        exclusive_rows.append(
+            {
+                "label": label,
+                "count": count,
+                "pct": (count / total_base * 100) if total_base else 0.0,
+            }
+        )
+    return rows, exclusive_rows
+
+
+def compute_table2(tam_records: List[Record]) -> List[Dict[str, object]]:
+    total_tam = len(tam_records)
+    rows: List[Dict[str, object]] = []
+    grouped: Dict[int, List[Record]] = defaultdict(list)
+    for rec in tam_records:
+        grouped[count_specialites(rec)].append(rec)
+
+    for key, label in [
+        (1, "1 spécialité"),
+        (2, "2 spécialités"),
+        (3, "3 spécialités"),
+    ]:
+        group = grouped.get(key, [])
+        stag_values = [rec.nb_stagiaires or 0.0 for rec in group]
+        prod_values = [
+            (rec.nb_stagiaires or 0.0) / rec.effectif
+            for rec in group
+            if rec.effectif
+        ]
+        effectif_values = [rec.effectif for rec in group if rec.effectif]
+        rows.append(
+            {
+                "label": label,
+                "tam_count": len(group),
+                "tam_pct": (len(group) / total_tam * 100) if total_tam else 0.0,
+                "stag_mean": average(stag_values),
+                "prod_mean": average(prod_values),
+                "effectif_mean": average(effectif_values),
+            }
+        )
+    return rows
+
+
+def normalize_label(spec: Optional[Tuple[Optional[str], Optional[str]]]) -> Optional[str]:
+    if spec is None:
+        return None
+    label = spec[1] or spec[0]
+    if not label:
+        return None
+    return label.strip()
+
+
+def compute_combinations(records: List[Record], tam_records: List[Record]) -> Tuple[List[Dict[str, object]], List[Dict[str, object]]]:
+    pair_counter: Counter = Counter()
+    total_multi = 0
+    for rec in records:
+        labels = []
+        for spec in rec.specialites:
+            label = normalize_label(spec)
+            if label and label not in labels:
+                labels.append(label)
+        if len(labels) >= 2:
+            total_multi += 1
+            labels_sorted = sorted(labels, key=str.casefold)
+            for a, b in itertools.combinations(labels_sorted, 2):
+                pair_counter[(a, b)] += 1
+
+    tam_pair_stag: Dict[Tuple[str, str], List[float]] = defaultdict(list)
+    for rec in tam_records:
+        labels = []
+        for spec in rec.specialites:
+            label = normalize_label(spec)
+            if label and label not in labels:
+                labels.append(label)
+        if len(labels) < 2:
+            continue
+        labels_sorted = sorted(labels, key=str.casefold)
+        for a, b in itertools.combinations(labels_sorted, 2):
+            tam_pair_stag[(a, b)].append(rec.nb_stagiaires or 0.0)
+
+    top_pairs = pair_counter.most_common(20)
+    rows: List[Dict[str, object]] = []
+    for rank, ((a, b), count) in enumerate(top_pairs, start=1):
+        stag_mean = average(tam_pair_stag.get((a, b), []))
+        rows.append(
+            {
+                "rank": rank,
+                "a": a,
+                "b": b,
+                "count": count,
+                "pct_multi": (count / total_multi * 100) if total_multi else 0.0,
+                "stag_mean": stag_mean,
+                "insight": f"Offre combinant {a} & {b}",
+            }
+        )
+
+    all_rows: List[Dict[str, object]] = []
+    for (a, b), count in pair_counter.most_common():
+        all_rows.append(
+            {
+                "specialite_1": a,
+                "specialite_2": b,
+                "of": count,
+                "pct_multi": (count / total_multi * 100) if total_multi else 0.0,
+                "stag_mean_tam": average(tam_pair_stag.get((a, b), [])),
+            }
+        )
+
+    return rows, all_rows
+
+
+def compute_table4(records: List[Record]) -> List[Dict[str, object]]:
+    region_groups: Dict[str, List[Record]] = defaultdict(list)
+    for rec in records:
+        if rec.region_code is None:
+            continue
+        name = REGION_NAMES.get(rec.region_code, "Autres territoires")
+        region_groups[name].append(rec)
+
+    rows: List[Dict[str, object]] = []
+    national_total = sum(len(recs) for recs in region_groups.values())
+    national_poly = sum(
+        sum(1 for r in recs if count_specialites(r) >= 2)
+        for recs in region_groups.values()
+    )
+    national_pct = (national_poly / national_total * 100) if national_total else 0.0
+
+    for name, recs in region_groups.items():
+        total = len(recs)
+        one_spec = sum(1 for r in recs if count_specialites(r) == 1)
+        multi = sum(1 for r in recs if count_specialites(r) >= 2)
+        poly_pct = (multi / total * 100) if total else 0.0
+        rows.append(
+            {
+                "region": name,
+                "one_spec": one_spec,
+                "multi_spec": multi,
+                "poly_pct": poly_pct,
+                "delta": poly_pct - national_pct,
+            }
+        )
+
+    rows.sort(key=lambda item: item["poly_pct"], reverse=True)
+    rows.append(
+        {
+            "region": "National",
+            "one_spec": sum(1 for r in records if count_specialites(r) == 1),
+            "multi_spec": sum(1 for r in records if count_specialites(r) >= 2),
+            "poly_pct": national_pct,
+            "delta": 0.0,
+        }
+    )
+    return rows
+
+
+def categorize_effectif(effectif: Optional[int]) -> Optional[str]:
+    if effectif is None:
+        return None
+    if effectif <= 2:
+        return "≤2"
+    if effectif == 3:
+        return "3"
+    if effectif == 4:
+        return "4"
+    if 5 <= effectif <= 6:
+        return "5-6"
+    if 7 <= effectif <= 8:
+        return "7-8"
+    if 9 <= effectif <= 10:
+        return "9-10"
+    return ">10"
+
+
+def compute_table5(tam_records: List[Record]) -> List[Dict[str, object]]:
+    groups: Dict[str, List[Record]] = defaultdict(list)
+    for rec in tam_records:
+        category = categorize_effectif(rec.effectif)
+        if category:
+            groups[category].append(rec)
+
+    ordered_categories = ["3", "4", "5-6", "7-8", "9-10"]
+    if any(cat not in ordered_categories for cat in groups):
+        for cat in sorted(groups.keys()):
+            if cat not in ordered_categories:
+                ordered_categories.append(cat)
+
+    rows: List[Dict[str, object]] = []
+    for cat in ordered_categories:
+        recs = groups.get(cat, [])
+        total = len(recs)
+        one_spec = sum(1 for r in recs if count_specialites(r) == 1)
+        two_spec = sum(1 for r in recs if count_specialites(r) == 2)
+        three_spec = sum(1 for r in recs if count_specialites(r) == 3)
+        poly_pct = ((two_spec + three_spec) / total * 100) if total else 0.0
+        rows.append(
+            {
+                "category": cat,
+                "one_spec": one_spec,
+                "two_spec": two_spec,
+                "three_spec": three_spec,
+                "poly_pct": poly_pct,
+            }
+        )
+    return rows
+
+
+def write_markdown(
+    table1: List[Dict[str, object]],
+    exclusive: List[Dict[str, object]],
+    table2: List[Dict[str, object]],
+    table3: List[Dict[str, object]],
+    table4: List[Dict[str, object]],
+    table5: List[Dict[str, object]],
+    summary: List[str],
+) -> None:
+    lines: List[str] = []
+    lines.append("# Analyse polyvalence OF France 2025")
+    lines.append("")
+
+    lines.append("## Tableau 1a : Spécialités déclarées (cumulatives)")
+    lines.append("| Nb spécialités | OF total | % base | OF TAM | % TAM | Stag. moyen TAM |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for row in table1:
+        lines.append(
+            "| {label} | {base} | {base_pct:.1f}% | {tam} | {tam_pct:.1f}% | {stag} |".format(
+                label=row["label"],
+                base=format_int(row["base_count"]),
+                base_pct=row["base_pct"],
+                tam=format_int(row["tam_count"]),
+                tam_pct=row["tam_pct"],
+                stag=format_float(row["stag_mean"], 0) if row["tam_count"] else "-",
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 1b : Répartition exclusive des OF")
+    lines.append("| Statut | OF | % base |")
+    lines.append("| --- | --- | --- |")
+    for row in exclusive:
+        lines.append(
+            "| {label} | {count} | {pct:.1f}% |".format(
+                label=row["label"],
+                count=format_int(row["count"]),
+                pct=row["pct"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 2 : Polyvalence vs activité (TAM)")
+    lines.append("| Nb spécialités | OF TAM | % TAM | Stag. moyen | Prod. estimée | Effectif moyen |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for row in table2:
+        lines.append(
+            "| {label} | {tam} | {tam_pct:.1f}% | {stag} | {prod} | {effectif} |".format(
+                label=row["label"],
+                tam=format_int(row["tam_count"]),
+                tam_pct=row["tam_pct"],
+                stag=format_float(row["stag_mean"], 0) if row["tam_count"] else "-",
+                prod=format_float(row["prod_mean"], 1) if row["tam_count"] else "-",
+                effectif=format_float(row["effectif_mean"], 1) if row["tam_count"] else "-",
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 3 : Paires de spécialités les plus fréquentes")
+    lines.append("| Rang | Spé 1 | Spé 2 | OF | % multi-spés | Stag. moyen TAM | Interprétation |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for row in table3:
+        lines.append(
+            "| {rank} | {a} | {b} | {count} | {pct:.1f}% | {stag} | {insight} |".format(
+                rank=row["rank"],
+                a=row["a"],
+                b=row["b"],
+                count=format_int(row["count"]),
+                pct=row["pct_multi"],
+                stag=format_float(row["stag_mean"], 0) if row["stag_mean"] else "-",
+                insight=row["insight"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 4 : Polyvalence par région")
+    lines.append("| Région | OF 1 spé | OF 2+ spés | % polyvalents | vs national (pp) |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in table4:
+        lines.append(
+            "| {region} | {one} | {multi} | {pct:.1f}% | {delta:+.1f} |".format(
+                region=row["region"],
+                one=format_int(row["one_spec"]),
+                multi=format_int(row["multi_spec"]),
+                pct=row["poly_pct"],
+                delta=row["delta"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Tableau 5 : Polyvalence selon l'effectif (TAM)")
+    lines.append("| Effectif | OF 1 spé | OF 2 spés | OF 3 spés | % polyvalents |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in table5:
+        lines.append(
+            "| {cat} | {one} | {two} | {three} | {pct:.1f}% |".format(
+                cat=row["category"],
+                one=format_int(row["one_spec"]),
+                two=format_int(row["two_spec"]),
+                three=format_int(row["three_spec"]),
+                pct=row["poly_pct"],
+            )
+        )
+    lines.append("")
+
+    lines.append("## Synthèse")
+    for bullet in summary:
+        lines.append(f"- {bullet}")
+
+    with open(OUTPUT_MARKDOWN, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def write_combinations_csv(rows: List[Dict[str, object]]) -> None:
+    fieldnames = ["specialite_1", "specialite_2", "of", "pct_multi", "stag_mean_tam"]
+    with open(OUTPUT_COMBOS_CSV, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def build_summary(
+    exclusive: List[Dict[str, object]],
+    table2: List[Dict[str, object]],
+    table3: List[Dict[str, object]],
+    table4: List[Dict[str, object]],
+    table5: List[Dict[str, object]],
+) -> List[str]:
+    spec_lookup = {row["label"]: row for row in exclusive}
+    poly_pct = spec_lookup.get("Polyvalents", {}).get("pct", 0.0)
+    divers_pct = spec_lookup.get("Diversifiés", {}).get("pct", 0.0)
+    spec_pct = spec_lookup.get("Spécialisés", {}).get("pct", 0.0)
+
+    tam_lookup = {row["label"]: row for row in table2}
+    stag1 = tam_lookup.get("1 spécialité", {}).get("stag_mean", 0.0)
+    stag2 = tam_lookup.get("2 spécialités", {}).get("stag_mean", 0.0)
+    stag3 = tam_lookup.get("3 spécialités", {}).get("stag_mean", 0.0)
+
+    top_pairs = table3[:3]
+    regions_sorted = [row for row in table4 if row["region"] != "National"]
+    top_region = next(
+        (row for row in regions_sorted if row["region"] != "Autres territoires"),
+        regions_sorted[0] if regions_sorted else None,
+    )
+    low_region = next(
+        (row for row in reversed(regions_sorted) if row["region"] != "Autres territoires"),
+        regions_sorted[-1] if regions_sorted else None,
+    )
+
+    effectif_high = max(table5, key=lambda row: row["poly_pct"], default=None)
+
+    summary: List[str] = []
+    summary.append(
+        "Répartition : {spec:.1f}% spécialisés (1 spé), {divers:.1f}% diversifiés (2 spés) et {poly:.1f}% polyvalents (3 spés).".format(
+            spec=spec_pct,
+            divers=divers_pct,
+            poly=poly_pct,
+        )
+    )
+    if stag3 and stag1:
+        uplift = stag3 - stag1
+        summary.append(
+            "TAM : les OF à 3 spés forment en moyenne {stag3:.0f} stagiaires (+{uplift:.0f} vs 1 spé).".format(
+                stag3=stag3,
+                uplift=uplift,
+            )
+        )
+    if top_pairs:
+        pair_text = "; ".join(
+            f"{row['a']} + {row['b']} ({format_int(row['count'])} OF)" for row in top_pairs
+        )
+        summary.append(f"Top combinaisons : {pair_text}.")
+    if top_region and low_region:
+        summary.append(
+            "Régions les plus polyvalentes : {high} ({pct_high:.1f}%), les moins : {low} ({pct_low:.1f}%).".format(
+                high=top_region["region"],
+                pct_high=top_region["poly_pct"],
+                low=low_region["region"],
+                pct_low=low_region["poly_pct"],
+            )
+        )
+    if effectif_high:
+        summary.append(
+            "Polyvalence et taille : pic à {cat} formateurs ({pct:.1f}% d'OF à 2+ spés).".format(
+                cat=effectif_high["category"],
+                pct=effectif_high["poly_pct"],
+            )
+        )
+    return summary
+
+
+def main() -> None:
+    ensure_output_dir()
+    records = load_records()
+    tam_records = [rec for rec in records if is_tam(rec)]
+
+    table1, exclusive = compute_table1(records, tam_records)
+    table2 = compute_table2(tam_records)
+    table3, combos_csv = compute_combinations(records, tam_records)
+    table4 = compute_table4(records)
+    table5 = compute_table5(tam_records)
+    summary = build_summary(exclusive, table2, table3, table4, table5)
+
+    write_markdown(table1, exclusive, table2, table3, table4, table5, summary)
+    write_combinations_csv(combos_csv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated script to compute multi-spécialité distributions, activity impacts, regional breakdowns, and effectif profiles
- generate the requested markdown report and full combination export for polyvalence analyses

## Testing
- python analyze_polyvalence.py

------
https://chatgpt.com/codex/tasks/task_e_68dde0585c8083318e1d3c7bd019f91c