### PR TITLE
Relax TAM filter to include networks lacking action counts

### DIFF
--- a/analysis_outputs/reseaux_nationaux.md
+++ b/analysis_outputs/reseaux_nationaux.md
@@ -4,15 +4,16 @@
 | Rang | SIREN | Nom réseau | Nb étab | Effectif total | OF TAM 3-10 | Régions | Spé principale |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 130017278 | CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE | 6 | 1 763 | 1 | Île-de-France | Tech/Digital |
+| 2 | 7756850198 | COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES | 3 | 881 | 1 | Auvergne-Rhône-Alpes, Provence-Alpes-Côte d'Azur, Île-de-France | Langues |
 
 ## Tableau 2 : Segmentation taille des réseaux
 | Taille réseau | Nb réseaux | Nb étab total | Effectif total | OF TAM 3-10 |
 | --- | --- | --- | --- | --- |
-| 3-5 étab | 0 | 0 | 0 | 0 |
+| 3-5 étab | 1 | 3 | 881 | 1 |
 | 6-10 étab | 1 | 6 | 1 763 | 1 |
 | 11-20 étab | 0 | 0 | 0 | 0 |
 | 21+ étab | 0 | 0 | 0 | 0 |
-| TOTAL | 1 | 6 | 1 763 | 1 |
+| TOTAL | 2 | 9 | 2 644 | 2 |
 
 ## Tableau 3 : Réseaux dominants par domaine
 | Macro-thème | Top réseau | Nb étab | OF TAM | Opportunité |
@@ -21,53 +22,58 @@
 | Tech/Digital | CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE | 6 | 1 | 1 OF TAM, locale |
 | Commerce/Gestion | Aucun réseau éligible | 0 | 0 | Données à qualifier |
 | Santé | Aucun réseau éligible | 0 | 0 | Données à qualifier |
-| Autres | Aucun réseau éligible | 0 | 0 | Données à qualifier |
+| Autres | COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES | 3 | 1 | 1 OF TAM, régionale |
 
 ## Tableau 4 : Implantation territoriale (Top 20)
 | Réseau | Nb étab | Nb régions | Régions présentes | Type couverture |
 | --- | --- | --- | --- | --- |
 | CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE | 6 | 1 | Île-de-France | Locale |
+| COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES | 3 | 3 | Auvergne-Rhône-Alpes, Provence-Alpes-Côte d'Azur, Île-de-France | Régionale |
 
 ## Tableau 5 : Réseaux vs indépendants (TAM)
 | Métrique | OF réseaux | OF indépendants | Différence |
 | --- | --- | --- | --- |
-| Nombre OF | 1 | 12 302 | -100.0% |
+| Nombre OF | 2 | 16 877 | -100.0% |
 | % TAM | 0.0 | 100.0 | -100.0 pts |
-| Stag. moyen | 15 | 266.1 | -94.4% |
-| Effectif moyen | 3 | 5.5 | -45.1% |
-| Production est. | 5 | 49.6 | -89.9% |
+| Stag. moyen | 15 | 246.6 | -93.9% |
+| Effectif moyen | 6 | 5.3 | +12.5% |
+| Production est. | 3.3 | 47.0 | -92.9% |
 
 ## Tableau 6 : Top 20 réseaux prioritaires
 | Rang | Réseau | Score | OF TAM | Couverture | Spé | Action |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE | 0.79 | 1 | Locale | Tech/Digital | Approche locale ciblée |
+| 2 | COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES | 0.63 | 1 | Régionale | Langues | Identifier relais régionaux |
 
 ## Tableau 7 : Typologie des réseaux
 | Type | Nb réseaux | Nb étab moy | Caractéristiques |
 | --- | --- | --- | --- |
 | Franchise | 0 | 0.0 | Aucun réseau éligible |
-| Groupe intégré | 1 | 6.0 | Portefeuille multi-marques |
+| Groupe intégré | 2 | 4.5 | Portefeuille multi-marques |
 | Coopérative | 0 | 0.0 | Aucun réseau éligible |
 
 ## Synthèse et actions
-RÉSEAUX IDENTIFIÉS : 1 réseaux (≥3 établissements)
+RÉSEAUX IDENTIFIÉS : 2 réseaux (≥3 établissements)
 
 Top 10 réseaux :
 1. CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE : 6 étab, 1 OF TAM, Île-de-France
+2. COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES : 3 étab, 1 OF TAM, Auvergne-Rhône-Alpes, Provence-Alpes-Côte d'Azur, Île-de-France
 
 Opportunité partenariats :
 - Aucun réseau national éligible (données à qualifier)
 - CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE = 1 OF dans TAM d'un coup
+- COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES = 1 OF TAM multi-régional (CEA)
 
 Réseaux vs indépendants :
 - Réseaux : 0.0% du TAM
 - Indépendants : 100.0% du TAM
-- Activité : Inférieure (-89.9%)
+- Activité : Inférieure (-92.9%)
 
 Qualité des données à surveiller :
-- 10 réseaux multi-sites sans OF dans le TAM 3-10
+- 9 réseaux multi-sites sans OF dans le TAM 3-10
 
 Actions recommandées :
 1. Engager CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE comme pilote partenariat
-2. Qualifier les effectifs des 10 réseaux hors TAM
+2. Qualifier les effectifs des 9 réseaux hors TAM
 3. Préparer offre multi-sites adaptée (tarification volume)
+

--- a/analysis_outputs/reseaux_top50.csv
+++ b/analysis_outputs/reseaux_top50.csv
@@ -1,2 +1,3 @@
 rang,siren,nom,nb_etablissements,effectif_total,of_tam,couverture,specialite,action
 1,130017278,CHAMBRE DE COMMERCE ET D INDUSTRIE DE REGION PARIS ILE DE FRANCE,6,1763,1,Locale,Tech/Digital,Proposer accompagnement de proximité
+2,7756850198,COMMISSARIAT A L'ENERGIE ATOMIQUE ET AUX ENERGIES ALTERNATIVES,3,881,1,Régionale,Langues,Structurer offre multi-régions

--- a/analyze_reseaux.py
+++ b/analyze_reseaux.py
@@ -255,8 +255,6 @@ def is_tam(record: Record) -> bool:
         return False
     if record.nb_stagiaires is None or record.nb_stagiaires <= 0:
         return False
-    if record.actions_form is None:
-        return False
     return True
 
 


### PR DESCRIPTION
## Summary
- allow TAM eligibility when actions data is missing so networks are filtered by effectif and stagiaires only
- regenerate the reseaux markdown and CSV outputs, adding the CEA network and refreshed metrics
- update the narrative summary to highlight the new multi-régional opportunity

## Testing
- python analyze_reseaux.py

------
https://chatgpt.com/codex/tasks/task_e_68df2ddf75648331ac81d8b5b9693fda