### PR TITLE
Add high-activity TAM analysis and premium ROI summary

### DIFF
--- a/analysis_outputs/prompt12_haute_activite.md
+++ b/analysis_outputs/prompt12_haute_activite.md
@@ -1,0 +1,149 @@
+## Tableau 1 : Tranches haute activité
+| Tranche stag./an | OF | % TAM | Effectif moy. | Stag./form | Prod est. (livr./mois) |
+| --- | --- | --- | --- | --- | --- |
+| 500-1000 | 922 | 7.6% | 6.4 | 106.3 | 56.7 |
+| 1000-2000 | 382 | 3.1% | 6.6 | 203.5 | 112.2 |
+| 2000-5000 | 134 | 1.1% | 6.6 | 402.7 | 223.1 |
+| 5000+ | 31 | 0.3% | 7.5 | 1 490.9 | 925.8 |
+| TOTAL ≥500 | 1 469 | 12.1% | 6.5 | 193.1 | 104.7 |
+
+## Tableau 2 : Profil type haute activité
+| Métrique | Haute activité (≥500) | TAM général | Écart |
+| --- | --- | --- | --- |
+| Nombre OF | 1 469 | 12 160 | 12.1% |
+| Part du TAM | 12.1% | 100% | - |
+| Effectif moyen | 6.5 | 5.5 | +19.0% |
+| Stagiaires moyen | 1 256 | 268 | +368.2% |
+| Stagiaires / formateur | 193.1 | 49.1 | +293.3% |
+| Prod est. (livr./mois) | 104.7 | 22.4 | +368.2% |
+
+## Tableau 3 : Répartition géographique
+| Région | OF ≥500 stag. | % région | % haute_act national |
+| --- | --- | --- | --- |
+| Île-de-France | 477 | 13.8% | 32.5% |
+| Auvergne-Rhône-Alpes | 213 | 13.4% | 14.5% |
+| Occitanie | 125 | 10.8% | 8.5% |
+| Provence-Alpes-Côte d'Azur | 109 | 10.2% | 7.4% |
+| Nouvelle-Aquitaine | 94 | 10.0% | 6.4% |
+| Hauts-de-France | 85 | 13.3% | 5.8% |
+| Grand Est | 82 | 11.0% | 5.6% |
+| Pays de la Loire | 77 | 12.4% | 5.2% |
+| Bretagne | 54 | 11.7% | 3.7% |
+| Bourgogne-Franche-Comté | 42 | 12.7% | 2.9% |
+| Centre-Val de Loire | 41 | 13.5% | 2.8% |
+| Normandie | 37 | 9.8% | 2.5% |
+| La Réunion | 8 | 4.6% | 0.5% |
+| Guadeloupe | 6 | 6.7% | 0.4% |
+| Martinique | 6 | 7.1% | 0.4% |
+| Corse | 5 | 9.4% | 0.3% |
+| Mayotte | 4 | 13.8% | 0.3% |
+| Guyane | 3 | 9.1% | 0.2% |
+| Autres régions | 1 | 100.0% | 0.1% |
+| TOTAL | 1 469 | - | 100.0% |
+
+## Tableau 4 : Spécialités haute activité
+| Macro-thème | OF ≥500 stag. | % macro | vs TAM général | Statut |
+| --- | --- | --- | --- | --- |
+| Autre | 333 | 22.7% | -3.8 pp | Sous-représenté |
+| Soft Skills | 304 | 20.7% | -0.3 pp | Aligné |
+| Commerce/Gestion | 157 | 10.7% | +1.2 pp | Sur-représenté |
+| Santé | 153 | 10.4% | +2.0 pp | Sur-représenté |
+| Sécurité | 138 | 9.4% | +6.4 pp | Sur-représenté |
+| Services | 136 | 9.3% | -2.5 pp | Sous-représenté |
+| Industrie | 104 | 7.1% | -0.2 pp | Aligné |
+| Tech/Digital | 72 | 4.9% | -1.3 pp | Sous-représenté |
+| Langues | 38 | 2.6% | -1.7 pp | Sous-représenté |
+| Juridique | 34 | 2.3% | +0.1 pp | Aligné |
+
+## Tableau 5 : Top 50 OF ultra-actifs
+| Rang | Dénomination | Dept | Effectif | Stagiaires | Stag./form | Spécialité | Prod est. (livr./mois) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | DIGITAL SKILLS FOUNDATION | - | 5 | 66 855 | 13 371.0 | Enseignement, formation | 5 571.2 |
+| 2 | BUTTERFLY AERO TRAINING | - | 7 | 59 466 | 8 495.1 | Transport, manutention, magasinage | 4 955.5 |
+| 3 | ORICA | - | 5 | 14 298 | 2 859.6 | Finances, banque, assurances | 1 191.5 |
+| 4 | INFANS GROUP | 69 | 4 | 11 827 | 2 956.8 | Linguistique | 985.6 |
+| 5 | P.E.C.S.  FRANCE | - | 8 | 10 648 | 1 331.0 | Enseignement, formation | 887.3 |
+| 6 | KAPTITUDE SAS | 94 | 9 | 10 254 | 1 139.3 | Sécurité des biens et des personnes, police, surveillance | 854.5 |
+| 7 | COOP-EGAL SARL | - | 8 | 9 180 | 1 147.5 | Ressources humaines, gestion du personnel, gestion de l'emploi | 765.0 |
+| 8 | KALEA FORMATION POUR LE DEVELOPPEMENT | 92 | 6 | 9 069 | 1 511.5 | Finances, banque, assurances | 755.8 |
+| 9 | SINFONI | - | 8 | 8 739 | 1 092.4 | Electricité, électronique (non compris automatisme et productique) | 728.2 |
+| 10 | IFIS  INTERACTIVE | - | 6 | 8 582 | 1 430.3 | Transformations chimiques et apparentées (y compris pharmaceutiques) | 715.2 |
+| 11 | SARL CVH | - | 7 | 8 401 | 1 200.1 | Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles | 700.1 |
+| 12 | I KNOW U WILL | - | 4 | 8 000 | 2 000.0 | Autres... | 666.7 |
+| 13 | YOOZ | - | 9 | 7 460 | 828.9 | Informatique, traitement de l'information, réseaux de transmission des données | 621.7 |
+| 14 | ACCORDIA | - | 9 | 7 277 | 808.6 | Ressources humaines, gestion du personnel, gestion de l'emploi | 606.4 |
+| 15 | SELARL HAAS SOCIETE D'AVOCATS | - | 10 | 7 235 | 723.5 | Droit, sciences politiques | 602.9 |
+| 16 | FRANCE PROTECTION FEU | 45 | 4 | 6 972 | 1 743.0 | Sécurité des biens et des personnes, police, surveillance | 581.0 |
+| 17 | MCDONALD'S FRANCE SERVICES | - | 10 | 6 959 | 695.9 | Développement des capacités comportementales et relationnelles | 579.9 |
+| 18 | REVERTO | - | 7 | 6 820 | 974.3 | Développement des capacités comportementales et relationnelles | 568.3 |
+| 19 | FAC & ASSOCIES | 63 | 8 | 6 706 | 838.2 | Droit, sciences politiques | 558.8 |
+| 20 | L'ECOLE DES METIERS DU FRAIS | - | 8 | 6 642 | 830.2 | Commerce, vente | 553.5 |
+| 21 | LAWREA | - | 6 | 6 482 | 1 080.3 | Spécialités plurivalentes des services | 540.2 |
+| 22 | GENESIA FINANCE | 75 | 10 | 6 382 | 638.2 | Finances, banque, assurances | 531.8 |
+| 23 | AM&JT | - | 9 | 6 298 | 699.8 | Finances, banque, assurances | 524.8 |
+| 24 | ANESTHESIA SAFETY NETWORK | 92 | 8 | 5 862 | 732.8 | Sciences de la vie | 488.5 |
+| 25 | CLAUDEPORET | 75 | 9 | 5 740 | 637.8 | Enseignement, formation | 478.3 |
+| 26 | VB MANAGEMENT | - | 10 | 5 672 | 567.2 | Sécurité des biens et des personnes, police, surveillance | 472.7 |
+| 27 | FMS INCENDIE | 60 | 6 | 5 626 | 937.7 | Sécurité des biens et des personnes, police, surveillance | 468.8 |
+| 28 | ASSOCIATION NATIONALE CONSEILS FINANCIERS   CIF | 75 | 9 | 5 359 | 595.4 | Finances, banque, assurances | 446.6 |
+| 29 | ASSISTANCE CONSEIL FORMATION | - | 6 | 5 304 | 884.0 | Sécurité des biens et des personnes, police, surveillance | 442.0 |
+| 30 | DID SECURITE | 68 | 9 | 5 217 | 579.7 | Sécurité des biens et des personnes, police, surveillance | 434.8 |
+| 31 | FORMEXPERT | 86 | 7 | 5 067 | 723.9 | Formations générales | 422.2 |
+| 32 | EVOLIS FORMATION | 59 | 10 | 4 975 | 497.5 | Enseignement, formation | 414.6 |
+| 33 | TECC FORMATION | - | 10 | 4 392 | 439.2 | Sécurité des biens et des personnes, police, surveillance | 366.0 |
+| 34 | SOC EUROPEENNE DE CONTROLE TECHNIQUE AUTOMOBILE (AUTOSUR) | - | 9 | 4 187 | 465.2 | Moteurs et mécanique auto | 348.9 |
+| 35 | LEMON ADDS | - | 5 | 4 095 | 819.0 | Développement des capacités comportementales et relationnelles | 341.2 |
+| 36 | FRANCE ELEVATEUR | - | 4 | 4 048 | 1 012.0 | Spécialités plutitechnologiques, mécanique-électricité | 337.3 |
+| 37 | SECURIFORM | - | 10 | 4 043 | 404.3 | Sécurité des biens et des personnes, police, surveillance | 336.9 |
+| 38 | EGS (NOM COMMERCIAL FORMAFORCE) | - | 5 | 3 985 | 797.0 | Bâtiment: construction et couverture | 332.1 |
+| 39 | ACADEMY DE LA FORMATION - SARL D.E.P. | 50 | 10 | 3 948 | 394.8 | Formations générales | 329.0 |
+| 40 | M&BOCA | - | 5 | 3 922 | 784.4 | Spécialités plurivalentes de la communication | 326.8 |
+| 41 | CENTAURE ILE DE FRANCE | - | 9 | 3 908 | 434.2 | Enseignement, formation | 325.7 |
+| 42 | FOCUS QUALITE | - | 5 | 3 752 | 750.4 | Santé | 312.7 |
+| 43 | SENIOR DENTAL CONFORT | 92 | 3 | 3 735 | 1 245.0 | Santé | 311.2 |
+| 44 | ERVE Philippe - PREV-ONE FORMATION | 49 | 5 | 3 645 | 729.0 | Sécurité des biens et des personnes, police, surveillance | 303.8 |
+| 45 | SELFORME | - | 9 | 3 563 | 395.9 | Energie, génie climatique | 296.9 |
+| 46 | SOCIETE FINANCIERE XAVIER HALLIGON - UP'TEAMHOMME | - | 5 | 3 540 | 708.0 | Ressources humaines, gestion du personnel, gestion de l'emploi | 295.0 |
+| 47 | AFOR+ SAS | 31 | 9 | 3 407 | 378.6 | Travail social | 283.9 |
+| 48 | IDEAL PREVENTION SECURITE AUDIT CONSEIL | - | 10 | 3 386 | 338.6 | Transport, manutention, magasinage | 282.2 |
+| 49 | ARCHE LIVIA | - | 7 | 3 352 | 478.9 | Spécialités plurivalentes sanitaires et sociales | 279.3 |
+| 50 | GUY HOQUET L'IMMOBILIER | 94 | 7 | 3 293 | 470.4 | Commerce, vente | 274.4 |
+
+## Tableau 6 : ROI Qalia haute activité
+| Métrique | Valeur |
+| --- | --- |
+| Prod est. moyenne (livr./mois) | 104.7 |
+| Temps gagné estimé (2h/livrable) | 209.4 |
+| Valeur temps (TJM 120€) | 25 123€ |
+| Coût Qalia | 299€ |
+| ROI net | 24 824€ |
+| ~ROI | ×84.0 |
+
+## Synthèse
+HAUTE ACTIVITÉ (≥500 stagiaires) :
+
+- Nombre OF : 1 469 (12.1% du TAM)
+
+Distribution :
+- 500-1000 : 62.8%
+- 1000-2000 : 26.0%
+- 2000+ : 11.2%
+
+Profil :
+- Effectif moyen : 6.5 formateurs
+- Stagiaires moyen : 1 256 / an
+- Production estimée : 104.7 livrables/mois
+
+Concentration :
+- Top 3 régions (Île-de-France, Auvergne-Rhône-Alpes, Occitanie) : 55.5% de la haute activité
+- Spécialités dominantes : Soft Skills, Commerce/Gestion, Santé
+
+Opportunité :
+- Segment premium identifié
+- ROI Qalia : ×84.0 (vs ×6.8 standard)
+- Recommandation : Pricing Team+ 499€/mois
+
+Actions :
+- Ciblage prioritaire haute activité
+- Messaging "Power users"
+- Cas d'usage production intensive

--- a/analysis_outputs/prompt12_top50_haute_activite.csv
+++ b/analysis_outputs/prompt12_top50_haute_activite.csv
@@ -1,0 +1,51 @@
+rang,denomination,code_postal,ville,adresse,region,dept,effectif,nb_stagiaires,stagiaires_par_formateur,specialite,production_estimee_livrables_par_mois
+1,DIGITAL SKILLS FOUNDATION,,,,Auvergne-Rhône-Alpes,-,5,66855,13371.0,"Enseignement, formation",5571.2
+2,BUTTERFLY AERO TRAINING,,,,Île-de-France,-,7,59466,8495.1,"Transport, manutention, magasinage",4955.5
+3,ORICA,,,,Hauts-de-France,-,5,14298,2859.6,"Finances, banque, assurances",1191.5
+4,INFANS GROUP,69150.0,DECINES CHARPIEU,8  AV SIMONE VEIL IMMEUBLE LE STADIUM DECINES CHARPIEU,Auvergne-Rhône-Alpes,69,4,11827,2956.8,Linguistique,985.6
+5,P.E.C.S.  FRANCE,,,,Île-de-France,-,8,10648,1331.0,"Enseignement, formation",887.3
+6,KAPTITUDE SAS,94230.0,CACHAN,45/47 AVENUE CARNOT,Île-de-France,94,9,10254,1139.3,"Sécurité des biens et des personnes, police, surveillance",854.5
+7,COOP-EGAL SARL,,,,Occitanie,-,8,9180,1147.5,"Ressources humaines, gestion du personnel, gestion de l'emploi",765.0
+8,KALEA FORMATION POUR LE DEVELOPPEMENT,92600.0,ASNIERES SUR SEINE,36  RUE DE NANTERRE,Île-de-France,92,6,9069,1511.5,"Finances, banque, assurances",755.8
+9,SINFONI,,,,Bretagne,-,8,8739,1092.4,"Electricité, électronique (non compris automatisme et productique)",728.2
+10,IFIS  INTERACTIVE,,,,Île-de-France,-,6,8582,1430.3,Transformations chimiques et apparentées (y compris pharmaceutiques),715.2
+11,SARL CVH,,,,Occitanie,-,7,8401,1200.1,"Développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles",700.1
+12,I KNOW U WILL,,,,Île-de-France,-,4,8000,2000.0,Autres...,666.7
+13,YOOZ,,,,Occitanie,-,9,7460,828.9,"Informatique, traitement de l'information, réseaux de transmission des données",621.7
+14,ACCORDIA,,,,Île-de-France,-,9,7277,808.6,"Ressources humaines, gestion du personnel, gestion de l'emploi",606.4
+15,SELARL HAAS SOCIETE D'AVOCATS,,,,Île-de-France,-,10,7235,723.5,"Droit, sciences politiques",602.9
+16,FRANCE PROTECTION FEU,45140.0,INGRE,01 ROUTE NATIONALE,Centre-Val de Loire,45,4,6972,1743.0,"Sécurité des biens et des personnes, police, surveillance",581.0
+17,MCDONALD'S FRANCE SERVICES,,,,Île-de-France,-,10,6959,695.9,Développement des capacités comportementales et relationnelles,579.9
+18,REVERTO,,,,Auvergne-Rhône-Alpes,-,7,6820,974.3,Développement des capacités comportementales et relationnelles,568.3
+19,FAC & ASSOCIES,63800.0,COURNON D AUVERGNE,46  RUE DE SARLIEVE,Auvergne-Rhône-Alpes,63,8,6706,838.2,"Droit, sciences politiques",558.8
+20,L'ECOLE DES METIERS DU FRAIS,,,,Auvergne-Rhône-Alpes,-,8,6642,830.2,"Commerce, vente",553.5
+21,LAWREA,,,,Auvergne-Rhône-Alpes,-,6,6482,1080.3,Spécialités plurivalentes des services,540.2
+22,GENESIA FINANCE,75001.0,PARIS 01,3  BD DE SEBASTOPOL,Île-de-France,75,10,6382,638.2,"Finances, banque, assurances",531.8
+23,AM&JT,,,,Occitanie,-,9,6298,699.8,"Finances, banque, assurances",524.8
+24,ANESTHESIA SAFETY NETWORK,92500.0,RUEIL MALMAISON,18 B RUE DES VAUSSOURDS,Île-de-France,92,8,5862,732.8,Sciences de la vie,488.5
+25,CLAUDEPORET,75015.0,PARIS 15,2 RUE SAINT SAENS,Île-de-France,75,9,5740,637.8,"Enseignement, formation",478.3
+26,VB MANAGEMENT,,,,Provence-Alpes-Côte d'Azur,-,10,5672,567.2,"Sécurité des biens et des personnes, police, surveillance",472.7
+27,FMS INCENDIE,60290.0,LAIGNEVILLE,1396 rue du 8 mai 1945,Hauts-de-France,60,6,5626,937.7,"Sécurité des biens et des personnes, police, surveillance",468.8
+28,ASSOCIATION NATIONALE CONSEILS FINANCIERS   CIF,75009.0,PARIS 09,92 rue d'Amsterdam,Île-de-France,75,9,5359,595.4,"Finances, banque, assurances",446.6
+29,ASSISTANCE CONSEIL FORMATION,,,,Bourgogne-Franche-Comté,-,6,5304,884.0,"Sécurité des biens et des personnes, police, surveillance",442.0
+30,DID SECURITE,68390.0,SAUSHEIM,5 AV PIERRE PFLIMLIN PARC ESPALE,Grand Est,68,9,5217,579.7,"Sécurité des biens et des personnes, police, surveillance",434.8
+31,FORMEXPERT,86180.0,BUXEROLLES,42 RUE DU PLANTY,Nouvelle-Aquitaine,86,7,5067,723.9,Formations générales,422.2
+32,EVOLIS FORMATION,59300.0,VALENCIENNES,59  BOULEVARD PATER,Hauts-de-France,59,10,4975,497.5,"Enseignement, formation",414.6
+33,TECC FORMATION,,,,Pays de la Loire,-,10,4392,439.2,"Sécurité des biens et des personnes, police, surveillance",366.0
+34,SOC EUROPEENNE DE CONTROLE TECHNIQUE AUTOMOBILE (AUTOSUR),,,,Île-de-France,-,9,4187,465.2,Moteurs et mécanique auto,348.9
+35,LEMON ADDS,,,,Nouvelle-Aquitaine,-,5,4095,819.0,Développement des capacités comportementales et relationnelles,341.2
+36,FRANCE ELEVATEUR,,,,Grand Est,-,4,4048,1012.0,"Spécialités plutitechnologiques, mécanique-électricité",337.3
+37,SECURIFORM,,,,Hauts-de-France,-,10,4043,404.3,"Sécurité des biens et des personnes, police, surveillance",336.9
+38,EGS (NOM COMMERCIAL FORMAFORCE),,,,Hauts-de-France,-,5,3985,797.0,Bâtiment: construction et couverture,332.1
+39,ACADEMY DE LA FORMATION - SARL D.E.P.,50113.0,CHERBOURG EN COTENTIN,130 Rue Longue Mare CHERBOURG EN COTENTIN,Normandie,50,10,3948,394.8,Formations générales,329.0
+40,M&BOCA,,,,Nouvelle-Aquitaine,-,5,3922,784.4,Spécialités plurivalentes de la communication,326.8
+41,CENTAURE ILE DE FRANCE,,,,Île-de-France,-,9,3908,434.2,"Enseignement, formation",325.7
+42,FOCUS QUALITE,,,,Occitanie,-,5,3752,750.4,Santé,312.7
+43,SENIOR DENTAL CONFORT,92270.0,BOIS COLOMBES,7  RUE DES PEUPLIERS,Île-de-France,92,3,3735,1245.0,Santé,311.2
+44,ERVE Philippe - PREV-ONE FORMATION,49450.0,ST MACAIRE EN MAUGES,"2, rue des Alouettes",Pays de la Loire,49,5,3645,729.0,"Sécurité des biens et des personnes, police, surveillance",303.8
+45,SELFORME,,,,Bourgogne-Franche-Comté,-,9,3563,395.9,"Energie, génie climatique",296.9
+46,SOCIETE FINANCIERE XAVIER HALLIGON - UP'TEAMHOMME,,,,Pays de la Loire,-,5,3540,708.0,"Ressources humaines, gestion du personnel, gestion de l'emploi",295.0
+47,AFOR+ SAS,31000.0,TOULOUSE,31 RUE DE METZ Appartement 46,Occitanie,31,9,3407,378.6,Travail social,283.9
+48,IDEAL PREVENTION SECURITE AUDIT CONSEIL,,,,Auvergne-Rhône-Alpes,-,10,3386,338.6,"Transport, manutention, magasinage",282.2
+49,ARCHE LIVIA,,,,Provence-Alpes-Côte d'Azur,-,7,3352,478.9,Spécialités plurivalentes sanitaires et sociales,279.3
+50,GUY HOQUET L'IMMOBILIER,94250.0,GENTILLY,39 AVENUE PAUL VAILLANT COUTURIER,Île-de-France,94,7,3293,470.4,"Commerce, vente",274.4

--- a/prompt12_haute_activite.py
+++ b/prompt12_haute_activite.py
@@ -1,0 +1,940 @@
+import csv
+import os
+import zipfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+XLSX_PATH = "OF 3-10.xlsx"
+OUTPUT_DIR = "analysis_outputs"
+OUTPUT_MARKDOWN = os.path.join(OUTPUT_DIR, "prompt12_haute_activite.md")
+OUTPUT_CSV = os.path.join(OUTPUT_DIR, "prompt12_top50_haute_activite.csv")
+
+NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+TARGET_MIN = 3
+TARGET_MAX = 10
+
+REGION_NAMES: Dict[int, str] = {
+    11: "Île-de-France",
+    24: "Centre-Val de Loire",
+    27: "Bourgogne-Franche-Comté",
+    28: "Normandie",
+    32: "Hauts-de-France",
+    44: "Grand Est",
+    52: "Pays de la Loire",
+    53: "Bretagne",
+    75: "Nouvelle-Aquitaine",
+    76: "Occitanie",
+    84: "Auvergne-Rhône-Alpes",
+    93: "Provence-Alpes-Côte d'Azur",
+    94: "Corse",
+    1: "Guadeloupe",
+    2: "Martinique",
+    3: "Guyane",
+    4: "La Réunion",
+    6: "Mayotte",
+    975: "Saint-Pierre-et-Miquelon",
+    977: "Saint-Barthélemy",
+    978: "Saint-Martin",
+    986: "Wallis-et-Futuna",
+    987: "Polynésie française",
+    988: "Nouvelle-Calédonie",
+    989: "Îles de Clipperton",
+}
+
+MACRO_THEMES = [
+    "Soft Skills",
+    "Tech/Digital",
+    "Commerce/Gestion",
+    "Santé",
+    "Langues",
+    "Juridique",
+    "Industrie",
+    "Services",
+    "Sécurité",
+    "Autre",
+]
+
+SPECIFIC_MAPPING: Dict[str, str] = {
+    "enseignement, formation": "Soft Skills",
+    "ressources humaines, gestion du personnel, gestion de l'emploi": "Soft Skills",
+    "développement des capacités comportementales et relationnelles": "Soft Skills",
+    "développement des capacités d'orientation, d'insertion ou de réinsertion sociales et professionnelles": "Soft Skills",
+    "formations générales": "Autre",
+    "pluridisciplinaire": "Autre",
+    "finances, banque, assurances": "Commerce/Gestion",
+    "banque et assurances": "Commerce/Gestion",
+    "comptabilité, gestion": "Commerce/Gestion",
+    "techniques de vente": "Commerce/Gestion",
+    "commerce, vente": "Commerce/Gestion",
+    "marketing": "Commerce/Gestion",
+    "soins infirmiers": "Santé",
+    "santé": "Santé",
+    "sanitaire et social": "Santé",
+    "travail social": "Santé",
+    "action sociale": "Santé",
+    "services domestiques": "Services",
+    "services à la personne": "Services",
+    "transport, manutention, magasinage": "Services",
+    "logistique, transport": "Services",
+    "bâtiment et travaux publics": "Industrie",
+    "génie civil, construction, bois": "Industrie",
+    "mécanique générale": "Industrie",
+    "mécanique et structures métalliques": "Industrie",
+    "maintenance industrielle": "Industrie",
+    "électronique": "Tech/Digital",
+    "électricité": "Industrie",
+    "énergie": "Industrie",
+    "informatique": "Tech/Digital",
+    "programmation, développement": "Tech/Digital",
+    "réseaux informatiques": "Tech/Digital",
+    "langues vivantes": "Langues",
+    "linguistique": "Langues",
+    "traduction, interprétation": "Langues",
+    "droit": "Juridique",
+    "sécurité des biens et des personnes": "Sécurité",
+    "sécurité, armée, police": "Sécurité",
+    "hôtellerie, restauration": "Services",
+    "tourisme": "Services",
+    "esthétique, coiffure": "Services",
+    "coiffure": "Services",
+    "esthétique": "Services",
+    "agriculture": "Autre",
+    "agronomie": "Autre",
+    "environnement": "Autre",
+}
+
+KEYWORD_RULES: List[Tuple[str, Tuple[str, ...]]] = [
+    (
+        "Tech/Digital",
+        (
+            "informatique",
+            "numér",
+            "programm",
+            "réseau",
+            "logiciel",
+            "digital",
+            "donnée",
+            "cyber",
+            "cloud",
+            "web",
+            "intelligence artificielle",
+            "information",
+        ),
+    ),
+    (
+        "Soft Skills",
+        (
+            "orientation",
+            "ressources humaines",
+            "gestion du personnel",
+            "enseignement",
+            "pédagog",
+            "insertion",
+            "comportement",
+            "formation de formateurs",
+        ),
+    ),
+    (
+        "Commerce/Gestion",
+        (
+            "vente",
+            "commercial",
+            "marketing",
+            "gestion",
+            "finance",
+            "banque",
+            "assurance",
+            "comptabil",
+            "achats",
+            "immobilier",
+        ),
+    ),
+    (
+        "Santé",
+        (
+            "sant",
+            "médic",
+            "paraméd",
+            "infirm",
+            "social",
+            "soin",
+            "pharma",
+            "handicap",
+        ),
+    ),
+    ("Langues", ("langue", "lingu", "tradu", "interpr")),
+    ("Juridique", ("droit", "jurid", "justice", "crimin", "sciences politiques")),
+    (
+        "Industrie",
+        (
+            "mécan",
+            "industri",
+            "électric",
+            "électrotech",
+            "maintenance",
+            "fabrication",
+            "production",
+            "chim",
+            "bâtiment",
+            "travaux publics",
+            "construction",
+            "métall",
+            "plasturg",
+            "energie",
+        ),
+    ),
+    (
+        "Services",
+        (
+            "service",
+            "transport",
+            "logist",
+            "coiff",
+            "esthé",
+            "restauration",
+            "hôtel",
+            "tourisme",
+            "nettoyage",
+            "sport",
+            "animation",
+            "santé animale",
+            "assistan",
+            "secrét",
+        ),
+    ),
+    ("Sécurité", ("sécur", "police", "gendar", "sûreté", "pompier", "secours", "défense")),
+]
+
+
+@dataclass
+class Record:
+    denomination: str
+    nb_stagiaires: float
+    effectif: Optional[int]
+    actions: Optional[int]
+    region_code: Optional[int]
+    specialite: Optional[str]
+    adresse: Optional[str]
+    code_postal: Optional[str]
+    ville: Optional[str]
+
+
+def ensure_output_dir() -> None:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def column_ref_to_index(ref: str) -> int:
+    letters = "".join(ch for ch in ref if ch.isalpha())
+    idx = 0
+    for ch in letters:
+        idx = idx * 26 + (ord(ch) - ord("A") + 1)
+    return idx - 1
+
+
+def load_shared_strings(zf: zipfile.ZipFile) -> List[str]:
+    shared: List[str] = []
+    path = "xl/sharedStrings.xml"
+    if path not in zf.namelist():
+        return shared
+    with zf.open(path) as f:
+        for _, elem in ET.iterparse(f, events=("end",)):
+            if elem.tag == NS + "si":
+                text = "".join(t.text or "" for t in elem.findall('.//' + NS + 't'))
+                shared.append(text)
+                elem.clear()
+    return shared
+
+
+def get_cell_value(cell: ET.Element, shared_strings: List[str]) -> Optional[str]:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "s":
+        v = cell.find(NS + "v")
+        if v is None or v.text is None:
+            return None
+        return shared_strings[int(v.text)]
+    if cell_type == "inlineStr":
+        is_elem = cell.find(NS + "is")
+        if is_elem is None:
+            return None
+        return "".join(t.text or "" for t in is_elem.findall('.//' + NS + 't'))
+    v = cell.find(NS + "v")
+    if v is None:
+        return None
+    return v.text
+
+
+def parse_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text or text.lower() == "nan":
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def parse_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text or text.lower() == "nan":
+        return None
+    try:
+        return int(float(text))
+    except ValueError:
+        return None
+
+
+def load_records() -> List[Record]:
+    records: List[Record] = []
+    with zipfile.ZipFile(XLSX_PATH) as zf:
+        shared_strings = load_shared_strings(zf)
+        with zf.open("xl/worksheets/sheet1.xml") as f:
+            header_map: Dict[int, str] = {}
+            target_indices: Dict[str, Optional[int]] = {
+                "denomination": None,
+                "nb_stagiaires": None,
+                "effectif": None,
+                "actions": None,
+                "region": None,
+                "specialite": None,
+                "adresse": None,
+                "code_postal": None,
+                "ville": None,
+            }
+            for _, elem in ET.iterparse(f, events=("end",)):
+                if elem.tag != NS + "row":
+                    continue
+                row_idx = int(elem.attrib.get("r"))
+                if row_idx == 1:
+                    for cell in elem.findall(NS + "c"):
+                        ref = cell.attrib.get("r")
+                        if not ref:
+                            continue
+                        col_idx = column_ref_to_index(ref)
+                        val = get_cell_value(cell, shared_strings)
+                        if val is not None:
+                            header_map[col_idx] = val
+                    target_indices["denomination"] = next(
+                        (idx for idx, name in header_map.items() if name == "denomination"),
+                        None,
+                    )
+                    target_indices["nb_stagiaires"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "informationsDeclarees.nbStagiaires"
+                        ),
+                        None,
+                    )
+                    target_indices["effectif"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "informationsDeclarees.effectifFormateurs"
+                        ),
+                        None,
+                    )
+                    target_indices["actions"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "certifications.actionsDeFormation"
+                        ),
+                        None,
+                    )
+                    target_indices["region"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "adressePhysiqueOrganismeFormation.codeRegion"
+                        ),
+                        None,
+                    )
+                    target_indices["specialite"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name
+                            == "informationsDeclarees.specialitesDeFormation.libelleSpecialite1"
+                        ),
+                        None,
+                    )
+                    target_indices["adresse"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "adressePhysiqueOrganismeFormation.voie"
+                        ),
+                        None,
+                    )
+                    target_indices["code_postal"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "adressePhysiqueOrganismeFormation.codePostal"
+                        ),
+                        None,
+                    )
+                    target_indices["ville"] = next(
+                        (
+                            idx
+                            for idx, name in header_map.items()
+                            if name == "adressePhysiqueOrganismeFormation.ville"
+                        ),
+                        None,
+                    )
+                    elem.clear()
+                    continue
+
+                indices = {idx for idx in target_indices.values() if idx is not None}
+                values: Dict[int, str] = {}
+                for cell in elem.findall(NS + "c"):
+                    ref = cell.attrib.get("r")
+                    if not ref:
+                        continue
+                    col_idx = column_ref_to_index(ref)
+                    if col_idx not in indices:
+                        continue
+                    val = get_cell_value(cell, shared_strings)
+                    if val is not None:
+                        values[col_idx] = val
+                denomination = str(values.get(target_indices["denomination"], ""))
+                nb_stagiaires = parse_float(values.get(target_indices["nb_stagiaires"])) or 0.0
+                effectif = parse_int(values.get(target_indices["effectif"]))
+                actions = parse_int(values.get(target_indices["actions"]))
+                region_code = parse_int(values.get(target_indices["region"]))
+                specialite = values.get(target_indices["specialite"])
+                if specialite is not None:
+                    specialite = specialite.strip()
+                    if not specialite:
+                        specialite = None
+                adresse = values.get(target_indices["adresse"])
+                if adresse:
+                    adresse = adresse.strip()
+                code_postal = values.get(target_indices["code_postal"])
+                if code_postal:
+                    code_postal = code_postal.strip()
+                ville = values.get(target_indices["ville"])
+                if ville:
+                    ville = ville.strip()
+                records.append(
+                    Record(
+                        denomination=denomination.strip(),
+                        nb_stagiaires=nb_stagiaires,
+                        effectif=effectif,
+                        actions=actions,
+                        region_code=region_code,
+                        specialite=specialite,
+                        adresse=adresse,
+                        code_postal=code_postal,
+                        ville=ville,
+                    )
+                )
+                elem.clear()
+    return records
+
+
+def is_tam(record: Record) -> bool:
+    if record.effectif is None or not (TARGET_MIN <= record.effectif <= TARGET_MAX):
+        return False
+    if record.actions != 1:
+        return False
+    if record.nb_stagiaires <= 0:
+        return False
+    return True
+
+
+def classify_specialite(label: Optional[str]) -> str:
+    if not label:
+        return "Autre"
+    norm = label.strip().lower()
+    if norm in SPECIFIC_MAPPING:
+        return SPECIFIC_MAPPING[norm]
+    if "formations générales" in norm or "non class" in norm:
+        return "Autre"
+    for theme, keywords in KEYWORD_RULES:
+        if any(keyword in norm for keyword in keywords):
+            return theme
+    return "Autre"
+
+
+def format_int(value: float) -> str:
+    return f"{int(round(value)):,}".replace(",", " ")
+
+
+def format_float(value: float, decimals: int = 1) -> str:
+    return f"{value:,.{decimals}f}".replace(",", " ")
+
+
+def format_percent(value: float, decimals: int = 1) -> str:
+    return f"{value:.{decimals}f}%"
+
+
+def safe_div(num: float, den: float) -> float:
+    return num / den if den else 0.0
+
+
+def compute_prod(nb_stagiaires: float) -> float:
+    return nb_stagiaires / 12.0
+
+
+def derive_dept(code_postal: Optional[str]) -> str:
+    if not code_postal:
+        return "-"
+    code = code_postal.strip()
+    if len(code) < 2:
+        return "-"
+    return code[:2]
+
+
+def build_table1(
+    high_records: List[Record], tam_records: List[Record]
+) -> Tuple[List[List[str]], List[Dict[str, float]]]:
+    tranches = [
+        ("500-1000", 500, 1000),
+        ("1000-2000", 1000, 2000),
+        ("2000-5000", 2000, 5000),
+        ("5000+", 5000, None),
+    ]
+    tam_total = len(tam_records)
+    total_high = len(high_records)
+    rows: List[List[str]] = []
+    distribution: List[Dict[str, float]] = []
+    for name, lower, upper in tranches:
+        subset = [
+            r
+            for r in high_records
+            if r.nb_stagiaires >= lower and (upper is None or r.nb_stagiaires < upper)
+        ]
+        if not subset:
+            rows.append([name, "0", "0.0%", "-", "-", "-"])
+            distribution.append({"name": name, "count": 0.0, "share_high": 0.0})
+            continue
+        count = len(subset)
+        pct_tam = count / tam_total * 100 if tam_total else 0.0
+        share_high = count / total_high * 100 if total_high else 0.0
+        effectif_mean = sum(r.effectif or 0 for r in subset) / count
+        stag_form = safe_div(sum(r.nb_stagiaires for r in subset), sum(r.effectif or 0 for r in subset))
+        prod_mean = sum(compute_prod(r.nb_stagiaires) for r in subset) / count
+        rows.append(
+            [
+                name,
+                format_int(count),
+                format_percent(pct_tam, 1),
+                format_float(effectif_mean, 1),
+                format_float(stag_form, 1),
+                format_float(prod_mean, 1),
+            ]
+        )
+        distribution.append({"name": name, "count": float(count), "share_high": share_high})
+    total_count = len(high_records)
+    total_pct = total_count / tam_total * 100 if tam_total else 0.0
+    effectif_mean = sum(r.effectif or 0 for r in high_records) / total_count if total_count else 0.0
+    stag_form = safe_div(
+        sum(r.nb_stagiaires for r in high_records), sum(r.effectif or 0 for r in high_records)
+    )
+    prod_mean = (
+        sum(compute_prod(r.nb_stagiaires) for r in high_records) / total_count if total_count else 0.0
+    )
+    rows.append(
+        [
+            "TOTAL ≥500",
+            format_int(total_count),
+            format_percent(total_pct, 1),
+            format_float(effectif_mean, 1),
+            format_float(stag_form, 1),
+            format_float(prod_mean, 1),
+        ]
+    )
+    return rows, distribution
+
+
+def build_table2(
+    high_records: List[Record], tam_records: List[Record]
+) -> Tuple[List[List[str]], Dict[str, float]]:
+    high_count = len(high_records)
+    tam_count = len(tam_records)
+    share = high_count / tam_count * 100 if tam_count else 0.0
+
+    def mean_effectif(records: List[Record]) -> float:
+        return sum(r.effectif or 0 for r in records) / len(records) if records else 0.0
+
+    def mean_stagiaires(records: List[Record]) -> float:
+        return sum(r.nb_stagiaires for r in records) / len(records) if records else 0.0
+
+    def ratio_stag_form(records: List[Record]) -> float:
+        return safe_div(sum(r.nb_stagiaires for r in records), sum(r.effectif or 0 for r in records))
+
+    def mean_prod(records: List[Record]) -> float:
+        return sum(compute_prod(r.nb_stagiaires) for r in records) / len(records) if records else 0.0
+
+    high_effectif = mean_effectif(high_records)
+    tam_effectif = mean_effectif(tam_records)
+    high_stag = mean_stagiaires(high_records)
+    tam_stag = mean_stagiaires(tam_records)
+    high_ratio = ratio_stag_form(high_records)
+    tam_ratio = ratio_stag_form(tam_records)
+    high_prod = mean_prod(high_records)
+    tam_prod = mean_prod(tam_records)
+
+    def format_ecart(high: float, base: float) -> str:
+        if base == 0:
+            return "-"
+        delta = (high / base) - 1
+        sign = "+" if delta >= 0 else ""
+        return f"{sign}{delta * 100:.1f}%"
+
+    rows = [
+        ["Nombre OF", format_int(high_count), format_int(tam_count), format_percent(share, 1)],
+        ["Part du TAM", format_percent(share, 1), "100%", "-"],
+        [
+            "Effectif moyen",
+            format_float(high_effectif, 1),
+            format_float(tam_effectif, 1),
+            format_ecart(high_effectif, tam_effectif),
+        ],
+        [
+            "Stagiaires moyen",
+            format_float(high_stag, 0),
+            format_float(tam_stag, 0),
+            format_ecart(high_stag, tam_stag),
+        ],
+        [
+            "Stagiaires / formateur",
+            format_float(high_ratio, 1),
+            format_float(tam_ratio, 1),
+            format_ecart(high_ratio, tam_ratio),
+        ],
+        [
+            "Prod est. (livr./mois)",
+            format_float(high_prod, 1),
+            format_float(tam_prod, 1),
+            format_ecart(high_prod, tam_prod),
+        ],
+    ]
+    stats = {
+        "share": share,
+        "high_effectif": high_effectif,
+        "high_stag": high_stag,
+        "high_ratio": high_ratio,
+        "high_prod": high_prod,
+    }
+    return rows, stats
+
+
+def build_table3(
+    high_records: List[Record], tam_records: List[Record]
+) -> Tuple[List[List[str]], List[Dict[str, float]]]:
+    region_totals: Dict[str, Dict[str, float]] = {}
+    for rec in tam_records:
+        if rec.region_code is None:
+            continue
+        label = REGION_NAMES.get(rec.region_code, "Autres régions")
+        stats = region_totals.setdefault(label, {"tam": 0.0, "high": 0.0})
+        stats["tam"] += 1
+    for rec in high_records:
+        if rec.region_code is None:
+            continue
+        label = REGION_NAMES.get(rec.region_code, "Autres régions")
+        stats = region_totals.setdefault(label, {"tam": 0.0, "high": 0.0})
+        stats["high"] += 1
+
+    total_high = len(high_records)
+    rows: List[List[str]] = []
+    region_details: List[Dict[str, float]] = []
+    for label, values in sorted(region_totals.items(), key=lambda item: item[1]["high"], reverse=True):
+        count_high = values["high"]
+        if count_high == 0:
+            continue
+        count_region = values["tam"]
+        pct_region = count_high / count_region * 100 if count_region else 0.0
+        pct_national = count_high / total_high * 100 if total_high else 0.0
+        rows.append(
+            [
+                label,
+                format_int(count_high),
+                format_percent(pct_region, 1),
+                format_percent(pct_national, 1),
+            ]
+        )
+        region_details.append({"region": label, "share": pct_national})
+    rows.append([
+        "TOTAL",
+        format_int(total_high),
+        "-",
+        "100.0%",
+    ])
+    return rows, region_details
+
+
+def build_table4(
+    high_records: List[Record], tam_records: List[Record]
+) -> Tuple[List[List[str]], List[Dict[str, float]]]:
+    theme_high: Dict[str, int] = {theme: 0 for theme in MACRO_THEMES}
+    theme_tam: Dict[str, int] = {theme: 0 for theme in MACRO_THEMES}
+    for rec in tam_records:
+        theme = classify_specialite(rec.specialite)
+        theme_tam[theme] = theme_tam.get(theme, 0) + 1
+    for rec in high_records:
+        theme = classify_specialite(rec.specialite)
+        theme_high[theme] = theme_high.get(theme, 0) + 1
+    total_high = sum(theme_high.values())
+    total_tam = sum(theme_tam.values())
+    rows: List[List[str]] = []
+    stats: List[Dict[str, float]] = []
+    for theme in MACRO_THEMES:
+        high_count = theme_high.get(theme, 0)
+        tam_count = theme_tam.get(theme, 0)
+        share_high = high_count / total_high * 100 if total_high else 0.0
+        share_tam = tam_count / total_tam * 100 if total_tam else 0.0
+        diff = share_high - share_tam
+        if share_tam == 0 and share_high > 0:
+            status = "Sur-représenté"
+        elif share_high >= share_tam * 1.1:
+            status = "Sur-représenté"
+        elif share_high <= share_tam * 0.9:
+            status = "Sous-représenté"
+        else:
+            status = "Aligné"
+        rows.append(
+            [
+                theme,
+                format_int(high_count),
+                format_percent(share_high, 1),
+                f"{diff:+.1f} pp",
+                status,
+            ]
+        )
+        stats.append({"theme": theme, "share": share_high})
+    rows.sort(key=lambda row: float(row[2].rstrip("%")), reverse=True)
+    stats.sort(key=lambda item: item["share"], reverse=True)
+    return rows, stats
+
+
+def build_table5(high_records: List[Record]) -> Tuple[List[List[str]], List[Dict[str, str]]]:
+    sorted_records = sorted(high_records, key=lambda r: r.nb_stagiaires, reverse=True)
+    rows: List[List[str]] = []
+    csv_rows: List[Dict[str, str]] = []
+    for rank, rec in enumerate(sorted_records[:50], start=1):
+        dept = derive_dept(rec.code_postal)
+        ratio = safe_div(rec.nb_stagiaires, rec.effectif or 0)
+        prod = compute_prod(rec.nb_stagiaires)
+        rows.append(
+            [
+                str(rank),
+                rec.denomination or "-",
+                dept,
+                format_int(rec.effectif or 0),
+                format_int(rec.nb_stagiaires),
+                format_float(ratio, 1),
+                rec.specialite or "-",
+                format_float(prod, 1),
+            ]
+        )
+        csv_rows.append(
+            {
+                "rang": str(rank),
+                "denomination": rec.denomination,
+                "code_postal": rec.code_postal or "",
+                "ville": rec.ville or "",
+                "adresse": rec.adresse or "",
+                "region": REGION_NAMES.get(rec.region_code, "Autres régions"),
+                "dept": dept,
+                "effectif": str(rec.effectif or ""),
+                "nb_stagiaires": str(int(round(rec.nb_stagiaires))),
+                "stagiaires_par_formateur": f"{ratio:.1f}" if ratio else "",
+                "specialite": rec.specialite or "",
+                "production_estimee_livrables_par_mois": f"{prod:.1f}",
+            }
+        )
+    return rows, csv_rows
+
+
+def build_table6(high_records: List[Record]) -> Tuple[List[List[str]], Dict[str, float]]:
+    prod_mean = sum(compute_prod(r.nb_stagiaires) for r in high_records) / len(high_records) if high_records else 0.0
+    heures_gagnees = prod_mean * 2
+    valeur = heures_gagnees * 120
+    cout = 299
+    roi_net = valeur - cout
+    multiplicateur = valeur / cout if cout else 0.0
+    rows = [
+        ["Prod est. moyenne (livr./mois)", format_float(prod_mean, 1)],
+        ["Temps gagné estimé (2h/livrable)", format_float(heures_gagnees, 1)],
+        ["Valeur temps (TJM 120€)", f"{valeur:,.0f}€".replace(",", " ")],
+        ["Coût Qalia", "299€"],
+        ["ROI net", f"{roi_net:,.0f}€".replace(",", " ")],
+        ["~ROI", f"×{multiplicateur:.1f}"],
+    ]
+    stats = {
+        "prod_mean": prod_mean,
+        "heures": heures_gagnees,
+        "valeur": valeur,
+        "roi_net": roi_net,
+        "multiplicateur": multiplicateur,
+    }
+    return rows, stats
+
+
+def write_csv(rows: List[Dict[str, str]]) -> None:
+    fieldnames = [
+        "rang",
+        "denomination",
+        "code_postal",
+        "ville",
+        "adresse",
+        "region",
+        "dept",
+        "effectif",
+        "nb_stagiaires",
+        "stagiaires_par_formateur",
+        "specialite",
+        "production_estimee_livrables_par_mois",
+    ]
+    with open(OUTPUT_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def render_table(title: str, headers: List[str], rows: List[List[str]]) -> List[str]:
+    lines = [title]
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+    return lines
+
+
+def generate_markdown() -> None:
+    ensure_output_dir()
+    records = load_records()
+    tam_records = [r for r in records if is_tam(r)]
+    high_records = [r for r in tam_records if r.nb_stagiaires >= 500]
+
+    table1, tranche_stats = build_table1(high_records, tam_records)
+    table2, profile_stats = build_table2(high_records, tam_records)
+    table3, region_stats = build_table3(high_records, tam_records)
+    table4, theme_stats = build_table4(high_records, tam_records)
+    table5, csv_rows = build_table5(high_records)
+    table6, roi_stats = build_table6(high_records)
+
+    write_csv(csv_rows)
+
+    lines: List[str] = []
+    lines.extend(render_table("## Tableau 1 : Tranches haute activité", [
+        "Tranche stag./an",
+        "OF",
+        "% TAM",
+        "Effectif moy.",
+        "Stag./form",
+        "Prod est. (livr./mois)",
+    ], table1))
+
+    lines.extend(render_table("## Tableau 2 : Profil type haute activité", [
+        "Métrique",
+        "Haute activité (≥500)",
+        "TAM général",
+        "Écart",
+    ], table2))
+
+    lines.extend(render_table("## Tableau 3 : Répartition géographique", [
+        "Région",
+        "OF ≥500 stag.",
+        "% région",
+        "% haute_act national",
+    ], table3))
+
+    lines.extend(render_table("## Tableau 4 : Spécialités haute activité", [
+        "Macro-thème",
+        "OF ≥500 stag.",
+        "% macro",
+        "vs TAM général",
+        "Statut",
+    ], table4))
+
+    lines.extend(render_table("## Tableau 5 : Top 50 OF ultra-actifs", [
+        "Rang",
+        "Dénomination",
+        "Dept",
+        "Effectif",
+        "Stagiaires",
+        "Stag./form",
+        "Spécialité",
+        "Prod est. (livr./mois)",
+    ], table5))
+
+    lines.extend(render_table("## Tableau 6 : ROI Qalia haute activité", [
+        "Métrique",
+        "Valeur",
+    ], table6))
+
+    total_high = len(high_records)
+    distribution_map = {item["name"]: item["share_high"] for item in tranche_stats}
+    dist_500_1000 = distribution_map.get("500-1000", 0.0)
+    dist_1000_2000 = distribution_map.get("1000-2000", 0.0)
+    dist_2000_plus = distribution_map.get("2000-5000", 0.0) + distribution_map.get("5000+", 0.0)
+    top_regions = region_stats[:3]
+    top_region_share = sum(item["share"] for item in top_regions)
+    top_region_labels = ", ".join(item["region"] for item in top_regions)
+    dominant_themes: List[str] = []
+    for item in theme_stats:
+        if item["theme"] == "Autre":
+            continue
+        dominant_themes.append(item["theme"])
+        if len(dominant_themes) == 3:
+            break
+    for item in theme_stats:
+        if len(dominant_themes) >= 3:
+            break
+        if item["theme"] not in dominant_themes:
+            dominant_themes.append(item["theme"])
+    dominant_theme_text = ", ".join(dominant_themes[:3])
+
+    lines.append("## Synthèse")
+    lines.append("HAUTE ACTIVITÉ (≥500 stagiaires) :")
+    lines.append("")
+    lines.append(
+        f"- Nombre OF : {format_int(total_high)} ({format_percent(profile_stats['share'], 1)} du TAM)"
+    )
+    lines.append("")
+    lines.append("Distribution :")
+    lines.append(f"- 500-1000 : {format_percent(dist_500_1000, 1)}")
+    lines.append(f"- 1000-2000 : {format_percent(dist_1000_2000, 1)}")
+    lines.append(f"- 2000+ : {format_percent(dist_2000_plus, 1)}")
+    lines.append("")
+    lines.append("Profil :")
+    lines.append(f"- Effectif moyen : {format_float(profile_stats['high_effectif'], 1)} formateurs")
+    lines.append(f"- Stagiaires moyen : {format_float(profile_stats['high_stag'], 0)} / an")
+    lines.append(f"- Production estimée : {format_float(roi_stats['prod_mean'], 1)} livrables/mois")
+    lines.append("")
+    lines.append("Concentration :")
+    lines.append(
+        f"- Top 3 régions ({top_region_labels}) : {format_percent(top_region_share, 1)} de la haute activité"
+    )
+    lines.append(f"- Spécialités dominantes : {dominant_theme_text}")
+    lines.append("")
+    lines.append("Opportunité :")
+    lines.append("- Segment premium identifié")
+    lines.append(
+        f"- ROI Qalia : ×{roi_stats['multiplicateur']:.1f} (vs ×6.8 standard)"
+    )
+    lines.append("- Recommandation : Pricing Team+ 499€/mois")
+    lines.append("")
+    lines.append("Actions :")
+    lines.append("- Ciblage prioritaire haute activité")
+    lines.append("- Messaging \"Power users\"")
+    lines.append("- Cas d'usage production intensive")
+    lines.append("")
+
+    with open(OUTPUT_MARKDOWN, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    generate_markdown()


### PR DESCRIPTION
## Summary
- add a dedicated script to parse the OF 3-10.xlsx workbook and isolate high-activity TAM providers
- generate a markdown report with six analysis tables plus an executive synthesis tailored to premium targeting
- export a Top 50 CSV including contact coordinates and production estimates for high-activity providers

## Testing
- `python prompt12_haute_activite.py`


------
https://chatgpt.com/codex/tasks/task_e_68df34b23f48833181265bae4340d737