### PR TITLE
Add prompt 15 data quality analysis outputs

### DIFF
--- a/analysis_outputs/prompt15_of_sans_cp.csv
+++ b/analysis_outputs/prompt15_of_sans_cp.csv
@@ -1,0 +1,20 @@
+codeRegion,region,of_tam_total,of_sans_cp,pct_sans_cp
+905,Autres DOM-TOM,1,0,0.0
+84,Auvergne-Rhône-Alpes,1601,701,43.8
+27,Bourgogne-Franche-Comté,335,132,39.4
+53,Bretagne,468,179,38.2
+24,Centre-Val de Loire,306,116,37.9
+94,Corse,54,3,5.6
+44,Grand Est,752,322,42.8
+1,Guadeloupe,91,12,13.2
+3,Guyane,33,9,27.3
+32,Hauts-de-France,653,336,51.5
+4,La Réunion,184,78,42.4
+2,Martinique,85,26,30.6
+6,Mayotte,30,10,33.3
+28,Normandie,383,179,46.7
+75,Nouvelle-Aquitaine,955,441,46.2
+76,Occitanie,1167,416,35.6
+52,Pays de la Loire,629,364,57.9
+93,Provence-Alpes-Côte d'Azur,1075,473,44.0
+11,Île-de-France,3501,1538,43.9

--- a/analysis_outputs/prompt15_qualite_donnees.md
+++ b/analysis_outputs/prompt15_qualite_donnees.md
@@ -1,0 +1,118 @@
+Tableau 1 : Taux de complétude des champs
+| Champ | Valeurs renseignées | % complétude | Utilisable ? |
+| --- | --- | --- | --- |
+| numeroDeclarationActivite | 154 107 | 100.0% | ✅ |
+| denomination | 154 107 | 100.0% | ✅ |
+| effectifFormateurs | 154 107 | 100.0% | ✅ |
+| nbStagiaires | 154 107 | 100.0% | ✅ |
+| codeRegion | 154 107 | 100.0% | ✅ |
+| codePostal | 79 587 | 51.6% | ⚠️ |
+| ville | 79 587 | 51.6% | ⚠️ |
+| voie | 79 587 | 51.6% | ⚠️ |
+| actionsDeFormation | 45 061 | 29.2% | ❌ |
+| libelleSpecialite1 | 144 906 | 94.0% | ✅ |
+| libelleSpecialite2 | 29 778 | 19.3% | ❌ |
+| libelleSpecialite3 | 12 642 | 8.2% | ❌ |
+
+Tableau 2 : Qualité des données régionales (TAM)
+| Région | OF TAM | % codePostal | % ville | % voie | Qualité globale |
+| --- | --- | --- | --- | --- | --- |
+| Auvergne-Rhône-Alpes | 1 601 | 56.2% | 56.2% | 56.2% | Moyenne |
+| Bourgogne-Franche-Comté | 335 | 60.6% | 60.6% | 60.6% | Bonne |
+| Bretagne | 468 | 61.8% | 61.8% | 61.8% | Bonne |
+| Centre-Val de Loire | 306 | 62.1% | 62.1% | 62.1% | Bonne |
+| Corse | 54 | 94.4% | 94.4% | 94.4% | Excellente |
+| Grand Est | 752 | 57.2% | 57.2% | 57.2% | Moyenne |
+| Guadeloupe | 91 | 86.8% | 86.8% | 86.8% | Excellente |
+| Guyane | 33 | 72.7% | 72.7% | 72.7% | Bonne |
+| Hauts-de-France | 653 | 48.5% | 48.5% | 48.5% | Moyenne |
+| La Réunion | 184 | 57.6% | 57.6% | 57.6% | Moyenne |
+| Martinique | 85 | 69.4% | 69.4% | 69.4% | Bonne |
+| Mayotte | 30 | 66.7% | 66.7% | 66.7% | Bonne |
+| Normandie | 383 | 53.3% | 53.3% | 53.3% | Moyenne |
+| Nouvelle-Aquitaine | 955 | 53.8% | 53.8% | 53.8% | Moyenne |
+| Occitanie | 1 167 | 64.4% | 64.4% | 64.4% | Bonne |
+| Pays de la Loire | 629 | 42.1% | 42.1% | 42.1% | Moyenne |
+| Provence-Alpes-Côte d'Azur | 1 075 | 56.0% | 56.0% | 56.0% | Moyenne |
+| Autres DOM-TOM | 1 | 100.0% | 100.0% | 100.0% | Excellente |
+| Île-de-France | 3 501 | 56.1% | 56.1% | 56.1% | Moyenne |
+| France | 12 303 | 56.6% | 56.6% | 56.6% | Moyenne |
+
+Tableau 3 : Faisabilité du ciblage par région
+| Région | Complétude CP | Stratégie acquisition |
+| --- | --- | --- |
+| Autres DOM-TOM | 100.0% | Ads géo Facebook/LinkedIn |
+| Corse | 94.4% | Ads géo Facebook/LinkedIn |
+| Guadeloupe | 86.8% | Ads géo Facebook/LinkedIn |
+| Guyane | 72.7% | Ads géo Facebook/LinkedIn |
+| Martinique | 69.4% | LinkedIn organique + Ads large |
+| Mayotte | 66.7% | LinkedIn organique + Ads large |
+| Occitanie | 64.4% | LinkedIn organique + Ads large |
+| Centre-Val de Loire | 62.1% | LinkedIn organique + Ads large |
+| Bretagne | 61.8% | LinkedIn organique + Ads large |
+| Bourgogne-Franche-Comté | 60.6% | LinkedIn organique + Ads large |
+| La Réunion | 57.6% | LinkedIn organique + Ads large |
+| Grand Est | 57.2% | LinkedIn organique + Ads large |
+| Auvergne-Rhône-Alpes | 56.2% | LinkedIn organique + Ads large |
+| Île-de-France | 56.1% | LinkedIn organique + Ads large |
+| Provence-Alpes-Côte d'Azur | 56.0% | LinkedIn organique + Ads large |
+| Nouvelle-Aquitaine | 53.8% | LinkedIn organique + Ads large |
+| Normandie | 53.3% | LinkedIn organique + Ads large |
+| Hauts-de-France | 48.5% | Contenu national uniquement |
+| Pays de la Loire | 42.1% | Contenu national uniquement |
+
+Tableau 4 : Profil des données manquantes
+| Caractéristique | OF avec CP | OF sans CP | Différence |
+| --- | --- | --- | --- |
+| Effectif moyen | 10.4 | 16.2 | +54.7% |
+| Stagiaires moyens | 192.6 | 272.8 | +41.6% |
+| Taux certif | 33.2 | 25.0 | -8.2 pp |
+| Région dominante | Île-de-France | Île-de-France | - |
+
+Tableau 5 : Niveau de spécialités renseignées
+| Nb spés renseignées | OF | % | Complétude |
+| --- | --- | --- | --- |
+| 0 | 9 201 | 6.0% | Aucune |
+| 1 | 115 128 | 74.7% | Minimale |
+| 2 | 17 136 | 11.1% | Bonne |
+| 3 | 12 642 | 8.2% | Complète |
+
+Tableau 6 : Plan d'amélioration de la qualité
+| Problème | Impact | Action recommandée | Priorité |
+| --- | --- | --- | --- |
+| 48% CP manquants | Limite ads géo | Enrichissement externe (LinkedIn) | 🔴 HAUTE |
+| 81% Spé2 manquants | Limite segmentation | Acceptable (Spé1 suffit) | 🟢 BASSE |
+| 92% Spé3 manquants | Limite analyse | Acceptable | 🟢 BASSE |
+
+## Synthèse
+QUALITÉ DONNÉES :
+Champs excellents (>90%) :
+- numeroDeclarationActivite
+- denomination
+- effectifFormateurs
+- nbStagiaires
+- codeRegion
+- libelleSpecialite1
+
+Champs problématiques (<60%) :
+- codePostal
+- ville
+- voie
+- actionsDeFormation
+- libelleSpecialite2
+- libelleSpecialite3
+
+Impact ciblage :
+- Régions >70% CP : 4 → Ads géo OK
+- Régions 50-70% CP : 13 → LinkedIn organique / Ads large
+- Régions <50% CP : 2 → Contenu organique
+
+Biais données manquantes :
+- Systématique
+- Impact : Stagiaires moyens sans CP 272.8 vs 192.6
+
+Recommandations :
+1. Enrichissement CP via LinkedIn (priorité HAUTE)
+2. Utiliser la région comme fallback de ciblage
+3. Spécialité 1 suffisante pour segmentation actuelle
+

--- a/prompt15_qualite_donnees.py
+++ b/prompt15_qualite_donnees.py
@@ -1,0 +1,568 @@
+import csv
+import os
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from compute_tam import (
+    NS,
+    OUTPUT_DIR,
+    REGION_NAMES,
+    TARGET_MAX,
+    TARGET_MIN,
+    column_ref_to_index,
+    get_cell_value,
+    load_shared_strings,
+)
+
+XLSX_PATH = "OF 3-10.xlsx"
+
+TARGET_HEADERS = {
+    "nda": "numeroDeclarationActivite",
+    "denomination": "denomination",
+    "effectif": "informationsDeclarees.effectifFormateurs",
+    "stagiaires": "informationsDeclarees.nbStagiaires",
+    "region": "adressePhysiqueOrganismeFormation.codeRegion",
+    "cp": "adressePhysiqueOrganismeFormation.codePostal",
+    "ville": "adressePhysiqueOrganismeFormation.ville",
+    "voie": "adressePhysiqueOrganismeFormation.voie",
+    "actions": "certifications.actionsDeFormation",
+    "spe1": "informationsDeclarees.specialitesDeFormation.libelleSpecialite1",
+    "spe2": "informationsDeclarees.specialitesDeFormation.libelleSpecialite2",
+    "spe3": "informationsDeclarees.specialitesDeFormation.libelleSpecialite3",
+}
+
+
+@dataclass
+class OFRecord:
+    nda: Optional[str]
+    denomination: Optional[str]
+    effectif: Optional[float]
+    stagiaires: Optional[float]
+    region_code: Optional[int]
+    code_postal: Optional[str]
+    ville: Optional[str]
+    voie: Optional[str]
+    actions: Optional[str]
+    spe1: Optional[str]
+    spe2: Optional[str]
+    spe3: Optional[str]
+
+
+def ensure_output_dir() -> None:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def parse_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def parse_float(value: Optional[str]) -> Optional[float]:
+    text = parse_text(value)
+    if text is None:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def parse_int(value: Optional[str]) -> Optional[int]:
+    text = parse_text(value)
+    if text is None:
+        return None
+    try:
+        return int(float(text))
+    except ValueError:
+        return None
+
+
+def normalize_numeric_text(value: Optional[str], pad_to: Optional[int] = None) -> Optional[str]:
+    text = parse_text(value)
+    if text is None:
+        return None
+    normalized = text
+    try:
+        decimal_value = Decimal(text)
+    except InvalidOperation:
+        return normalized
+    if decimal_value == decimal_value.to_integral():
+        normalized = str(int(decimal_value))
+    else:
+        normalized = format(decimal_value, "f")
+    if pad_to is not None and normalized.isdigit():
+        if len(normalized) < pad_to:
+            normalized = normalized.zfill(pad_to)
+    return normalized
+
+
+def load_records() -> List[OFRecord]:
+    records: List[OFRecord] = []
+    with zipfile.ZipFile(XLSX_PATH) as zf:
+        shared_strings = load_shared_strings(zf)
+        with zf.open("xl/worksheets/sheet1.xml") as f:
+            header_map: Dict[int, str] = {}
+            target_indices: Dict[str, Optional[int]] = {key: None for key in TARGET_HEADERS}
+            for event, elem in ET.iterparse(f, events=("end",)):
+                if elem.tag != NS + "row":
+                    continue
+                row_index = int(elem.attrib.get("r"))
+                if row_index == 1:
+                    for cell in elem.findall(NS + "c"):
+                        ref = cell.attrib.get("r")
+                        if not ref:
+                            continue
+                        col_idx = column_ref_to_index(ref)
+                        header_map[col_idx] = get_cell_value(cell, shared_strings)
+                    for key, header_name in TARGET_HEADERS.items():
+                        target_indices[key] = next(
+                            (idx for idx, name in header_map.items() if name == header_name),
+                            None,
+                        )
+                    elem.clear()
+                    continue
+
+                values: Dict[str, Optional[str]] = {key: None for key in TARGET_HEADERS}
+                for cell in elem.findall(NS + "c"):
+                    ref = cell.attrib.get("r")
+                    if not ref:
+                        continue
+                    col_idx = column_ref_to_index(ref)
+                    for key, idx in target_indices.items():
+                        if idx is not None and col_idx == idx:
+                            values[key] = get_cell_value(cell, shared_strings)
+                record = OFRecord(
+                    nda=normalize_numeric_text(values["nda"]),
+                    denomination=parse_text(values["denomination"]),
+                    effectif=parse_float(values["effectif"]),
+                    stagiaires=parse_float(values["stagiaires"]),
+                    region_code=parse_int(values["region"]),
+                    code_postal=normalize_numeric_text(values["cp"], pad_to=5),
+                    ville=parse_text(values["ville"]),
+                    voie=parse_text(values["voie"]),
+                    actions=parse_text(values["actions"]),
+                    spe1=parse_text(values["spe1"]),
+                    spe2=parse_text(values["spe2"]),
+                    spe3=parse_text(values["spe3"]),
+                )
+                records.append(record)
+                elem.clear()
+    return records
+
+
+def presence(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def format_int(value: int) -> str:
+    return f"{value:,}".replace(",", " ")
+
+
+def format_percent(value: float, decimals: int = 1) -> str:
+    return f"{value:.{decimals}f}%"
+
+
+def classify_field(pct: float) -> str:
+    if pct > 90:
+        return "✅"
+    if pct >= 50:
+        return "⚠️"
+    return "❌"
+
+
+def classify_quality(cp_pct: float) -> str:
+    if cp_pct > 80:
+        return "Excellente"
+    if cp_pct >= 60:
+        return "Bonne"
+    if cp_pct >= 40:
+        return "Moyenne"
+    return "Faible"
+
+
+def acquisition_strategy(cp_pct: float) -> str:
+    if cp_pct > 70:
+        return "Ads géo Facebook/LinkedIn"
+    if cp_pct >= 50:
+        return "LinkedIn organique + Ads large"
+    return "Contenu national uniquement"
+
+
+def safe_mean(values: Iterable[float]) -> Optional[float]:
+    data = [v for v in values if v is not None]
+    if not data:
+        return None
+    return sum(data) / len(data)
+
+
+def format_optional(value: Optional[float], decimals: int = 1) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{decimals}f}"
+
+
+def format_difference(base: Optional[float], compare: Optional[float]) -> str:
+    if base is None or compare is None or base == 0:
+        return "-"
+    diff = (compare - base) / base * 100
+    sign = "+" if diff >= 0 else ""
+    return f"{sign}{diff:.1f}%"
+
+
+def format_pp_difference(base: Optional[float], compare: Optional[float]) -> str:
+    if base is None or compare is None:
+        return "-"
+    diff = (compare - base) * 100
+    sign = "+" if diff >= 0 else ""
+    return f"{sign}{diff:.1f} pp"
+
+
+def dominant_region(records: List[OFRecord]) -> str:
+    counts: Counter[int] = Counter()
+    for rec in records:
+        if rec.region_code is None:
+            continue
+        counts[rec.region_code] += 1
+    if not counts:
+        return "-"
+    code, _ = counts.most_common(1)[0]
+    return REGION_NAMES.get(code, "Autres DOM-TOM")
+
+
+def write_markdown_table(lines: List[str], title: str, headers: List[str], rows: List[List[str]]) -> None:
+    lines.append(title)
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+
+
+try:
+    import zipfile
+    import xml.etree.ElementTree as ET
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(f"Missing standard library dependency: {exc}")
+
+
+def main() -> None:
+    ensure_output_dir()
+    records = load_records()
+    total_records = len(records)
+
+    completeness_fields = [
+        ("numeroDeclarationActivite", "nda"),
+        ("denomination", "denomination"),
+        ("effectifFormateurs", "effectif"),
+        ("nbStagiaires", "stagiaires"),
+        ("codeRegion", "region_code"),
+        ("codePostal", "code_postal"),
+        ("ville", "ville"),
+        ("voie", "voie"),
+        ("actionsDeFormation", "actions"),
+        ("libelleSpecialite1", "spe1"),
+        ("libelleSpecialite2", "spe2"),
+        ("libelleSpecialite3", "spe3"),
+    ]
+
+    field_counts: Dict[str, int] = {}
+    for field_key, attr in completeness_fields:
+        count = sum(1 for rec in records if presence(getattr(rec, attr)))
+        field_counts[field_key] = count
+
+    table1_rows: List[List[str]] = []
+    for field_key, attr in completeness_fields:
+        count = field_counts[field_key]
+        pct = (count / total_records * 100) if total_records else 0
+        status = classify_field(pct)
+        table1_rows.append(
+            [
+                field_key,
+                format_int(count),
+                format_percent(pct),
+                status,
+            ]
+        )
+
+    tam_records = [
+        rec
+        for rec in records
+        if rec.effectif is not None
+        and TARGET_MIN <= rec.effectif <= TARGET_MAX
+        and presence(rec.actions)
+        and rec.stagiaires is not None
+        and rec.stagiaires > 0
+    ]
+
+    region_stats: Dict[int, Dict[str, float]] = {}
+    region_records: Dict[int, List[OFRecord]] = defaultdict(list)
+    for rec in tam_records:
+        code = rec.region_code if rec.region_code is not None else -1
+        region_records[code].append(rec)
+
+    table2_rows: List[List[str]] = []
+    for code, recs in sorted(region_records.items(), key=lambda item: REGION_NAMES.get(item[0], "zzz")):
+        total = len(recs)
+        cp_pct = sum(1 for r in recs if presence(r.code_postal)) / total * 100 if total else 0
+        ville_pct = sum(1 for r in recs if presence(r.ville)) / total * 100 if total else 0
+        voie_pct = sum(1 for r in recs if presence(r.voie)) / total * 100 if total else 0
+        quality = classify_quality(cp_pct)
+        name = REGION_NAMES.get(code, "Autres DOM-TOM")
+        table2_rows.append(
+            [
+                name,
+                format_int(total),
+                format_percent(cp_pct),
+                format_percent(ville_pct),
+                format_percent(voie_pct),
+                quality,
+            ]
+        )
+        region_stats[code] = {
+            "total": total,
+            "cp_pct": cp_pct,
+            "ville_pct": ville_pct,
+            "voie_pct": voie_pct,
+            "name": name,
+        }
+
+    total_tam = len(tam_records)
+    if total_tam:
+        cp_total_pct = sum(1 for r in tam_records if presence(r.code_postal)) / total_tam * 100
+        ville_total_pct = sum(1 for r in tam_records if presence(r.ville)) / total_tam * 100
+        voie_total_pct = sum(1 for r in tam_records if presence(r.voie)) / total_tam * 100
+    else:
+        cp_total_pct = ville_total_pct = voie_total_pct = 0
+    table2_rows.append(
+        [
+            "France",
+            format_int(total_tam),
+            format_percent(cp_total_pct),
+            format_percent(ville_total_pct),
+            format_percent(voie_total_pct),
+            classify_quality(cp_total_pct),
+        ]
+    )
+
+    table3_rows: List[List[str]] = []
+    for code, stats in sorted(region_stats.items(), key=lambda item: item[1]["cp_pct"], reverse=True):
+        table3_rows.append(
+            [
+                stats["name"],
+                format_percent(stats["cp_pct"]),
+                acquisition_strategy(stats["cp_pct"]),
+            ]
+        )
+
+    with_cp = [rec for rec in records if presence(rec.code_postal)]
+    without_cp = [rec for rec in records if not presence(rec.code_postal)]
+
+    effectif_with = safe_mean(r.effectif for r in with_cp if r.effectif is not None)
+    effectif_without = safe_mean(r.effectif for r in without_cp if r.effectif is not None)
+    stag_with = safe_mean(r.stagiaires for r in with_cp if r.stagiaires is not None)
+    stag_without = safe_mean(r.stagiaires for r in without_cp if r.stagiaires is not None)
+    cert_with = sum(1 for r in with_cp if presence(r.actions)) / len(with_cp) if with_cp else None
+    cert_without = sum(1 for r in without_cp if presence(r.actions)) / len(without_cp) if without_cp else None
+
+    table4_rows = [
+        [
+            "Effectif moyen",
+            format_optional(effectif_with),
+            format_optional(effectif_without),
+            format_difference(effectif_with, effectif_without),
+        ],
+        [
+            "Stagiaires moyens",
+            format_optional(stag_with),
+            format_optional(stag_without),
+            format_difference(stag_with, stag_without),
+        ],
+        [
+            "Taux certif",
+            format_optional(cert_with * 100 if cert_with is not None else None),
+            format_optional(cert_without * 100 if cert_without is not None else None),
+            format_pp_difference(cert_with, cert_without),
+        ],
+        [
+            "Région dominante",
+            dominant_region(with_cp),
+            dominant_region(without_cp),
+            "-",
+        ],
+    ]
+
+    speciality_counter = Counter()
+    for rec in records:
+        count = sum(1 for field in (rec.spe1, rec.spe2, rec.spe3) if presence(field))
+        speciality_counter[count] += 1
+
+    labels = {
+        0: "Aucune",
+        1: "Minimale",
+        2: "Bonne",
+        3: "Complète",
+    }
+    table5_rows: List[List[str]] = []
+    for count in range(0, 4):
+        total = speciality_counter.get(count, 0)
+        pct = total / total_records * 100 if total_records else 0
+        table5_rows.append(
+            [
+                str(count),
+                format_int(total),
+                format_percent(pct),
+                labels.get(count, "-"),
+            ]
+        )
+
+    cp_missing_pct = 100 - (field_counts["codePostal"] / total_records * 100 if total_records else 0)
+    spe2_missing_pct = 100 - (field_counts["libelleSpecialite2"] / total_records * 100 if total_records else 0)
+    spe3_missing_pct = 100 - (field_counts["libelleSpecialite3"] / total_records * 100 if total_records else 0)
+
+    table6_rows = [
+        [
+            f"{cp_missing_pct:.0f}% CP manquants",
+            "Limite ads géo",
+            "Enrichissement externe (LinkedIn)",
+            "🔴 HAUTE",
+        ],
+        [
+            f"{spe2_missing_pct:.0f}% Spé2 manquants",
+            "Limite segmentation",
+            "Acceptable (Spé1 suffit)",
+            "🟢 BASSE",
+        ],
+        [
+            f"{spe3_missing_pct:.0f}% Spé3 manquants",
+            "Limite analyse",
+            "Acceptable",
+            "🟢 BASSE",
+        ],
+    ]
+
+    markdown_lines: List[str] = []
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 1 : Taux de complétude des champs",
+        ["Champ", "Valeurs renseignées", "% complétude", "Utilisable ?"],
+        table1_rows,
+    )
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 2 : Qualité des données régionales (TAM)",
+        ["Région", "OF TAM", "% codePostal", "% ville", "% voie", "Qualité globale"],
+        table2_rows,
+    )
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 3 : Faisabilité du ciblage par région",
+        ["Région", "Complétude CP", "Stratégie acquisition"],
+        table3_rows,
+    )
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 4 : Profil des données manquantes",
+        ["Caractéristique", "OF avec CP", "OF sans CP", "Différence"],
+        table4_rows,
+    )
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 5 : Niveau de spécialités renseignées",
+        ["Nb spés renseignées", "OF", "%", "Complétude"],
+        table5_rows,
+    )
+    write_markdown_table(
+        markdown_lines,
+        "Tableau 6 : Plan d'amélioration de la qualité",
+        ["Problème", "Impact", "Action recommandée", "Priorité"],
+        table6_rows,
+    )
+
+    excellent_fields = [
+        name
+        for name, attr in completeness_fields
+        if (field_counts[name] / total_records * 100 if total_records else 0) > 90
+    ]
+    weak_fields = [
+        name
+        for name, attr in completeness_fields
+        if (field_counts[name] / total_records * 100 if total_records else 0) < 60
+    ]
+
+    regions_above_70 = sum(1 for stats in region_stats.values() if stats["cp_pct"] > 70)
+    regions_between_50_70 = sum(1 for stats in region_stats.values() if 50 <= stats["cp_pct"] <= 70)
+    regions_below_50 = sum(1 for stats in region_stats.values() if stats["cp_pct"] < 50)
+
+    bias_conclusion = "Systématique" if abs((stag_without or 0) - (stag_with or 0)) > 10 else "Aléatoire"
+
+    markdown_lines.append("## Synthèse")
+    markdown_lines.append("QUALITÉ DONNÉES :")
+    markdown_lines.append("Champs excellents (>90%) :")
+    if excellent_fields:
+        for field in excellent_fields:
+            markdown_lines.append(f"- {field}")
+    else:
+        markdown_lines.append("- Aucun")
+    markdown_lines.append("")
+    markdown_lines.append("Champs problématiques (<60%) :")
+    if weak_fields:
+        for field in weak_fields:
+            markdown_lines.append(f"- {field}")
+    else:
+        markdown_lines.append("- Aucun")
+    markdown_lines.append("")
+    markdown_lines.append("Impact ciblage :")
+    markdown_lines.append(
+        f"- Régions >70% CP : {regions_above_70} → Ads géo OK"
+    )
+    markdown_lines.append(
+        f"- Régions 50-70% CP : {regions_between_50_70} → LinkedIn organique / Ads large"
+    )
+    markdown_lines.append(
+        f"- Régions <50% CP : {regions_below_50} → Contenu organique"
+    )
+    markdown_lines.append("")
+    markdown_lines.append("Biais données manquantes :")
+    markdown_lines.append(f"- {bias_conclusion}")
+    markdown_lines.append(
+        f"- Impact : Stagiaires moyens sans CP {format_optional(stag_without)} vs {format_optional(stag_with)}"
+    )
+    markdown_lines.append("")
+    markdown_lines.append("Recommandations :")
+    markdown_lines.append("1. Enrichissement CP via LinkedIn (priorité HAUTE)")
+    markdown_lines.append("2. Utiliser la région comme fallback de ciblage")
+    markdown_lines.append("3. Spécialité 1 suffisante pour segmentation actuelle")
+
+    output_path = os.path.join(OUTPUT_DIR, "prompt15_qualite_donnees.md")
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(markdown_lines))
+
+    csv_path = os.path.join(OUTPUT_DIR, "prompt15_of_sans_cp.csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["codeRegion", "region", "of_tam_total", "of_sans_cp", "pct_sans_cp"])
+        for code, stats in sorted(region_stats.items(), key=lambda item: item[1]["name"]):
+            total = stats["total"]
+            sans_cp = sum(1 for r in region_records[code] if not presence(r.code_postal))
+            pct = sans_cp / total * 100 if total else 0
+            writer.writerow([
+                code,
+                stats["name"],
+                total,
+                sans_cp,
+                f"{pct:.1f}",
+            ])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Prompt 15 analysis script to compute data quality KPIs for the OF 3-10 dataset
- generate markdown tables and a CSV export covering completeness, regional targeting, and missing data patterns

## Testing
- python prompt15_qualite_donnees.py

------
https://chatgpt.com/codex/tasks/task_e_68df3e06fab48331b5ab86a300479f63