### PR TITLE
Add TAM final computation and deliverables

### DIFF
--- a/analysis_outputs/prompt18_tam_final.csv
+++ b/analysis_outputs/prompt18_tam_final.csv
@@ -1,0 +1,1127 @@
+region,effectif,macro_theme,tam_base,tam_final
+Autres DOM-TOM,9,Autre,1,0.7
+Auvergne-Rhône-Alpes,3,Autre,86,60.2
+Auvergne-Rhône-Alpes,3,Commerce/Gestion,40,28.0
+Auvergne-Rhône-Alpes,3,Industrie,30,21.0
+Auvergne-Rhône-Alpes,3,Juridique,14,9.8
+Auvergne-Rhône-Alpes,3,Langues,14,9.8
+Auvergne-Rhône-Alpes,3,Santé,27,18.9
+Auvergne-Rhône-Alpes,3,Services,36,25.2
+Auvergne-Rhône-Alpes,3,Soft Skills,78,54.6
+Auvergne-Rhône-Alpes,3,Sécurité,18,12.6
+Auvergne-Rhône-Alpes,3,Tech/Digital,28,19.6
+Auvergne-Rhône-Alpes,4,Autre,76,53.2
+Auvergne-Rhône-Alpes,4,Commerce/Gestion,32,22.4
+Auvergne-Rhône-Alpes,4,Industrie,34,23.8
+Auvergne-Rhône-Alpes,4,Juridique,4,2.8
+Auvergne-Rhône-Alpes,4,Langues,21,14.7
+Auvergne-Rhône-Alpes,4,Santé,21,14.7
+Auvergne-Rhône-Alpes,4,Services,29,20.3
+Auvergne-Rhône-Alpes,4,Soft Skills,67,46.9
+Auvergne-Rhône-Alpes,4,Sécurité,5,3.5
+Auvergne-Rhône-Alpes,4,Tech/Digital,23,16.1
+Auvergne-Rhône-Alpes,5,Autre,72,50.4
+Auvergne-Rhône-Alpes,5,Commerce/Gestion,26,18.2
+Auvergne-Rhône-Alpes,5,Industrie,25,17.5
+Auvergne-Rhône-Alpes,5,Juridique,8,5.6
+Auvergne-Rhône-Alpes,5,Langues,9,6.3
+Auvergne-Rhône-Alpes,5,Santé,21,14.7
+Auvergne-Rhône-Alpes,5,Services,27,18.9
+Auvergne-Rhône-Alpes,5,Soft Skills,50,35.0
+Auvergne-Rhône-Alpes,5,Sécurité,9,6.3
+Auvergne-Rhône-Alpes,5,Tech/Digital,10,7.0
+Auvergne-Rhône-Alpes,6,Autre,52,36.4
+Auvergne-Rhône-Alpes,6,Commerce/Gestion,15,10.5
+Auvergne-Rhône-Alpes,6,Industrie,22,15.4
+Auvergne-Rhône-Alpes,6,Juridique,3,2.1
+Auvergne-Rhône-Alpes,6,Langues,5,3.5
+Auvergne-Rhône-Alpes,6,Santé,24,16.8
+Auvergne-Rhône-Alpes,6,Services,21,14.7
+Auvergne-Rhône-Alpes,6,Soft Skills,34,23.8
+Auvergne-Rhône-Alpes,6,Sécurité,4,2.8
+Auvergne-Rhône-Alpes,6,Tech/Digital,9,6.3
+Auvergne-Rhône-Alpes,7,Autre,32,22.4
+Auvergne-Rhône-Alpes,7,Commerce/Gestion,14,9.8
+Auvergne-Rhône-Alpes,7,Industrie,13,9.1
+Auvergne-Rhône-Alpes,7,Juridique,4,2.8
+Auvergne-Rhône-Alpes,7,Langues,4,2.8
+Auvergne-Rhône-Alpes,7,Santé,12,8.4
+Auvergne-Rhône-Alpes,7,Services,22,15.4
+Auvergne-Rhône-Alpes,7,Soft Skills,21,14.7
+Auvergne-Rhône-Alpes,7,Sécurité,4,2.8
+Auvergne-Rhône-Alpes,7,Tech/Digital,8,5.6
+Auvergne-Rhône-Alpes,8,Autre,35,24.5
+Auvergne-Rhône-Alpes,8,Commerce/Gestion,11,7.7
+Auvergne-Rhône-Alpes,8,Industrie,14,9.8
+Auvergne-Rhône-Alpes,8,Juridique,2,1.4
+Auvergne-Rhône-Alpes,8,Langues,6,4.2
+Auvergne-Rhône-Alpes,8,Santé,17,11.9
+Auvergne-Rhône-Alpes,8,Services,20,14.0
+Auvergne-Rhône-Alpes,8,Soft Skills,15,10.5
+Auvergne-Rhône-Alpes,8,Sécurité,3,2.1
+Auvergne-Rhône-Alpes,8,Tech/Digital,10,7.0
+Auvergne-Rhône-Alpes,9,Autre,27,18.9
+Auvergne-Rhône-Alpes,9,Commerce/Gestion,9,6.3
+Auvergne-Rhône-Alpes,9,Industrie,8,5.6
+Auvergne-Rhône-Alpes,9,Juridique,3,2.1
+Auvergne-Rhône-Alpes,9,Langues,7,4.9
+Auvergne-Rhône-Alpes,9,Santé,10,7.0
+Auvergne-Rhône-Alpes,9,Services,11,7.7
+Auvergne-Rhône-Alpes,9,Soft Skills,18,12.6
+Auvergne-Rhône-Alpes,9,Sécurité,6,4.2
+Auvergne-Rhône-Alpes,9,Tech/Digital,6,4.2
+Auvergne-Rhône-Alpes,10,Autre,26,18.2
+Auvergne-Rhône-Alpes,10,Commerce/Gestion,10,7.0
+Auvergne-Rhône-Alpes,10,Industrie,7,4.9
+Auvergne-Rhône-Alpes,10,Juridique,2,1.4
+Auvergne-Rhône-Alpes,10,Langues,9,6.3
+Auvergne-Rhône-Alpes,10,Santé,11,7.7
+Auvergne-Rhône-Alpes,10,Services,12,8.4
+Auvergne-Rhône-Alpes,10,Soft Skills,13,9.1
+Auvergne-Rhône-Alpes,10,Sécurité,2,1.4
+Auvergne-Rhône-Alpes,10,Tech/Digital,8,5.6
+Bourgogne-Franche-Comté,3,Autre,15,10.5
+Bourgogne-Franche-Comté,3,Commerce/Gestion,9,6.3
+Bourgogne-Franche-Comté,3,Industrie,5,3.5
+Bourgogne-Franche-Comté,3,Langues,1,0.7
+Bourgogne-Franche-Comté,3,Santé,5,3.5
+Bourgogne-Franche-Comté,3,Services,15,10.5
+Bourgogne-Franche-Comté,3,Soft Skills,19,13.3
+Bourgogne-Franche-Comté,3,Sécurité,1,0.7
+Bourgogne-Franche-Comté,3,Tech/Digital,2,1.4
+Bourgogne-Franche-Comté,4,Autre,13,9.1
+Bourgogne-Franche-Comté,4,Commerce/Gestion,4,2.8
+Bourgogne-Franche-Comté,4,Industrie,6,4.2
+Bourgogne-Franche-Comté,4,Juridique,2,1.4
+Bourgogne-Franche-Comté,4,Langues,1,0.7
+Bourgogne-Franche-Comté,4,Santé,3,2.1
+Bourgogne-Franche-Comté,4,Services,5,3.5
+Bourgogne-Franche-Comté,4,Soft Skills,15,10.5
+Bourgogne-Franche-Comté,4,Sécurité,1,0.7
+Bourgogne-Franche-Comté,4,Tech/Digital,5,3.5
+Bourgogne-Franche-Comté,5,Autre,13,9.1
+Bourgogne-Franche-Comté,5,Commerce/Gestion,7,4.9
+Bourgogne-Franche-Comté,5,Industrie,2,1.4
+Bourgogne-Franche-Comté,5,Langues,2,1.4
+Bourgogne-Franche-Comté,5,Santé,1,0.7
+Bourgogne-Franche-Comté,5,Services,6,4.2
+Bourgogne-Franche-Comté,5,Soft Skills,9,6.3
+Bourgogne-Franche-Comté,5,Sécurité,3,2.1
+Bourgogne-Franche-Comté,5,Tech/Digital,4,2.8
+Bourgogne-Franche-Comté,6,Autre,11,7.7
+Bourgogne-Franche-Comté,6,Commerce/Gestion,6,4.2
+Bourgogne-Franche-Comté,6,Industrie,1,0.7
+Bourgogne-Franche-Comté,6,Juridique,1,0.7
+Bourgogne-Franche-Comté,6,Santé,4,2.8
+Bourgogne-Franche-Comté,6,Services,3,2.1
+Bourgogne-Franche-Comté,6,Soft Skills,11,7.7
+Bourgogne-Franche-Comté,6,Sécurité,3,2.1
+Bourgogne-Franche-Comté,6,Tech/Digital,2,1.4
+Bourgogne-Franche-Comté,7,Autre,11,7.7
+Bourgogne-Franche-Comté,7,Commerce/Gestion,4,2.8
+Bourgogne-Franche-Comté,7,Industrie,4,2.8
+Bourgogne-Franche-Comté,7,Juridique,1,0.7
+Bourgogne-Franche-Comté,7,Langues,1,0.7
+Bourgogne-Franche-Comté,7,Santé,4,2.8
+Bourgogne-Franche-Comté,7,Services,3,2.1
+Bourgogne-Franche-Comté,7,Soft Skills,5,3.5
+Bourgogne-Franche-Comté,7,Sécurité,4,2.8
+Bourgogne-Franche-Comté,7,Tech/Digital,1,0.7
+Bourgogne-Franche-Comté,8,Autre,9,6.3
+Bourgogne-Franche-Comté,8,Commerce/Gestion,2,1.4
+Bourgogne-Franche-Comté,8,Industrie,1,0.7
+Bourgogne-Franche-Comté,8,Langues,1,0.7
+Bourgogne-Franche-Comté,8,Santé,2,1.4
+Bourgogne-Franche-Comté,8,Services,6,4.2
+Bourgogne-Franche-Comté,8,Soft Skills,6,4.2
+Bourgogne-Franche-Comté,8,Tech/Digital,1,0.7
+Bourgogne-Franche-Comté,9,Autre,9,6.3
+Bourgogne-Franche-Comté,9,Commerce/Gestion,4,2.8
+Bourgogne-Franche-Comté,9,Industrie,3,2.1
+Bourgogne-Franche-Comté,9,Juridique,1,0.7
+Bourgogne-Franche-Comté,9,Santé,4,2.8
+Bourgogne-Franche-Comté,9,Services,2,1.4
+Bourgogne-Franche-Comté,9,Soft Skills,7,4.9
+Bourgogne-Franche-Comté,10,Autre,4,2.8
+Bourgogne-Franche-Comté,10,Commerce/Gestion,1,0.7
+Bourgogne-Franche-Comté,10,Industrie,4,2.8
+Bourgogne-Franche-Comté,10,Langues,1,0.7
+Bourgogne-Franche-Comté,10,Santé,5,3.5
+Bourgogne-Franche-Comté,10,Services,5,3.5
+Bourgogne-Franche-Comté,10,Soft Skills,1,0.7
+Bourgogne-Franche-Comté,10,Sécurité,1,0.7
+Bourgogne-Franche-Comté,10,Tech/Digital,1,0.7
+Bretagne,3,Autre,20,14.0
+Bretagne,3,Commerce/Gestion,9,6.3
+Bretagne,3,Industrie,9,6.3
+Bretagne,3,Juridique,1,0.7
+Bretagne,3,Langues,6,4.2
+Bretagne,3,Santé,7,4.9
+Bretagne,3,Services,23,16.1
+Bretagne,3,Soft Skills,35,24.5
+Bretagne,3,Sécurité,4,2.8
+Bretagne,3,Tech/Digital,7,4.9
+Bretagne,4,Autre,23,16.1
+Bretagne,4,Commerce/Gestion,8,5.6
+Bretagne,4,Industrie,4,2.8
+Bretagne,4,Juridique,2,1.4
+Bretagne,4,Langues,4,2.8
+Bretagne,4,Santé,4,2.8
+Bretagne,4,Services,8,5.6
+Bretagne,4,Soft Skills,16,11.2
+Bretagne,4,Sécurité,3,2.1
+Bretagne,4,Tech/Digital,3,2.1
+Bretagne,5,Autre,16,11.2
+Bretagne,5,Commerce/Gestion,5,3.5
+Bretagne,5,Industrie,3,2.1
+Bretagne,5,Juridique,1,0.7
+Bretagne,5,Langues,3,2.1
+Bretagne,5,Santé,3,2.1
+Bretagne,5,Services,10,7.0
+Bretagne,5,Soft Skills,13,9.1
+Bretagne,5,Sécurité,4,2.8
+Bretagne,5,Tech/Digital,4,2.8
+Bretagne,6,Autre,11,7.7
+Bretagne,6,Commerce/Gestion,5,3.5
+Bretagne,6,Industrie,2,1.4
+Bretagne,6,Santé,4,2.8
+Bretagne,6,Services,14,9.8
+Bretagne,6,Soft Skills,10,7.0
+Bretagne,6,Sécurité,2,1.4
+Bretagne,6,Tech/Digital,2,1.4
+Bretagne,7,Autre,14,9.8
+Bretagne,7,Commerce/Gestion,3,2.1
+Bretagne,7,Industrie,3,2.1
+Bretagne,7,Juridique,1,0.7
+Bretagne,7,Langues,2,1.4
+Bretagne,7,Santé,4,2.8
+Bretagne,7,Services,4,2.8
+Bretagne,7,Soft Skills,7,4.9
+Bretagne,7,Sécurité,4,2.8
+Bretagne,8,Autre,13,9.1
+Bretagne,8,Commerce/Gestion,5,3.5
+Bretagne,8,Industrie,6,4.2
+Bretagne,8,Santé,5,3.5
+Bretagne,8,Services,6,4.2
+Bretagne,8,Soft Skills,6,4.2
+Bretagne,8,Tech/Digital,7,4.9
+Bretagne,9,Autre,5,3.5
+Bretagne,9,Commerce/Gestion,5,3.5
+Bretagne,9,Industrie,5,3.5
+Bretagne,9,Langues,2,1.4
+Bretagne,9,Santé,5,3.5
+Bretagne,9,Services,8,5.6
+Bretagne,9,Soft Skills,8,5.6
+Bretagne,9,Tech/Digital,1,0.7
+Bretagne,10,Autre,8,5.6
+Bretagne,10,Commerce/Gestion,1,0.7
+Bretagne,10,Industrie,7,4.9
+Bretagne,10,Langues,3,2.1
+Bretagne,10,Santé,4,2.8
+Bretagne,10,Services,2,1.4
+Bretagne,10,Soft Skills,3,2.1
+Bretagne,10,Sécurité,2,1.4
+Bretagne,10,Tech/Digital,1,0.7
+Centre-Val de Loire,3,Autre,23,16.1
+Centre-Val de Loire,3,Commerce/Gestion,5,3.5
+Centre-Val de Loire,3,Industrie,6,4.2
+Centre-Val de Loire,3,Langues,2,1.4
+Centre-Val de Loire,3,Santé,7,4.9
+Centre-Val de Loire,3,Services,12,8.4
+Centre-Val de Loire,3,Soft Skills,19,13.3
+Centre-Val de Loire,3,Sécurité,2,1.4
+Centre-Val de Loire,3,Tech/Digital,5,3.5
+Centre-Val de Loire,4,Autre,17,11.9
+Centre-Val de Loire,4,Commerce/Gestion,2,1.4
+Centre-Val de Loire,4,Industrie,4,2.8
+Centre-Val de Loire,4,Juridique,1,0.7
+Centre-Val de Loire,4,Langues,3,2.1
+Centre-Val de Loire,4,Santé,4,2.8
+Centre-Val de Loire,4,Services,10,7.0
+Centre-Val de Loire,4,Soft Skills,21,14.7
+Centre-Val de Loire,4,Sécurité,3,2.1
+Centre-Val de Loire,4,Tech/Digital,6,4.2
+Centre-Val de Loire,5,Autre,9,6.3
+Centre-Val de Loire,5,Commerce/Gestion,3,2.1
+Centre-Val de Loire,5,Industrie,2,1.4
+Centre-Val de Loire,5,Langues,2,1.4
+Centre-Val de Loire,5,Santé,7,4.9
+Centre-Val de Loire,5,Services,7,4.9
+Centre-Val de Loire,5,Soft Skills,9,6.3
+Centre-Val de Loire,5,Sécurité,2,1.4
+Centre-Val de Loire,5,Tech/Digital,1,0.7
+Centre-Val de Loire,6,Autre,11,7.7
+Centre-Val de Loire,6,Commerce/Gestion,3,2.1
+Centre-Val de Loire,6,Industrie,3,2.1
+Centre-Val de Loire,6,Langues,2,1.4
+Centre-Val de Loire,6,Services,7,4.9
+Centre-Val de Loire,6,Soft Skills,6,4.2
+Centre-Val de Loire,6,Sécurité,2,1.4
+Centre-Val de Loire,6,Tech/Digital,4,2.8
+Centre-Val de Loire,7,Autre,3,2.1
+Centre-Val de Loire,7,Commerce/Gestion,1,0.7
+Centre-Val de Loire,7,Industrie,1,0.7
+Centre-Val de Loire,7,Santé,2,1.4
+Centre-Val de Loire,7,Services,1,0.7
+Centre-Val de Loire,7,Soft Skills,7,4.9
+Centre-Val de Loire,7,Sécurité,1,0.7
+Centre-Val de Loire,7,Tech/Digital,1,0.7
+Centre-Val de Loire,8,Autre,4,2.8
+Centre-Val de Loire,8,Commerce/Gestion,6,4.2
+Centre-Val de Loire,8,Industrie,6,4.2
+Centre-Val de Loire,8,Langues,2,1.4
+Centre-Val de Loire,8,Santé,4,2.8
+Centre-Val de Loire,8,Services,2,1.4
+Centre-Val de Loire,8,Soft Skills,5,3.5
+Centre-Val de Loire,9,Autre,3,2.1
+Centre-Val de Loire,9,Commerce/Gestion,4,2.8
+Centre-Val de Loire,9,Industrie,1,0.7
+Centre-Val de Loire,9,Langues,2,1.4
+Centre-Val de Loire,9,Santé,2,1.4
+Centre-Val de Loire,10,Autre,6,4.2
+Centre-Val de Loire,10,Commerce/Gestion,1,0.7
+Centre-Val de Loire,10,Industrie,3,2.1
+Centre-Val de Loire,10,Langues,1,0.7
+Centre-Val de Loire,10,Santé,1,0.7
+Centre-Val de Loire,10,Services,2,1.4
+Centre-Val de Loire,10,Soft Skills,2,1.4
+Corse,3,Autre,3,2.1
+Corse,3,Industrie,1,0.7
+Corse,3,Santé,3,2.1
+Corse,3,Services,3,2.1
+Corse,3,Soft Skills,4,2.8
+Corse,4,Autre,3,2.1
+Corse,4,Industrie,1,0.7
+Corse,4,Santé,1,0.7
+Corse,4,Services,1,0.7
+Corse,4,Soft Skills,5,3.5
+Corse,4,Sécurité,2,1.4
+Corse,4,Tech/Digital,1,0.7
+Corse,5,Autre,2,1.4
+Corse,5,Commerce/Gestion,1,0.7
+Corse,5,Langues,1,0.7
+Corse,5,Services,2,1.4
+Corse,5,Soft Skills,1,0.7
+Corse,5,Sécurité,1,0.7
+Corse,6,Autre,2,1.4
+Corse,6,Santé,1,0.7
+Corse,6,Services,2,1.4
+Corse,6,Soft Skills,2,1.4
+Corse,6,Tech/Digital,1,0.7
+Corse,7,Autre,1,0.7
+Corse,7,Soft Skills,1,0.7
+Corse,8,Autre,1,0.7
+Corse,8,Industrie,1,0.7
+Corse,8,Services,1,0.7
+Corse,8,Soft Skills,1,0.7
+Corse,8,Sécurité,1,0.7
+Corse,9,Autre,1,0.7
+Corse,10,Santé,1,0.7
+Corse,10,Services,1,0.7
+Grand Est,3,Autre,46,32.2
+Grand Est,3,Commerce/Gestion,16,11.2
+Grand Est,3,Industrie,11,7.7
+Grand Est,3,Langues,8,5.6
+Grand Est,3,Santé,14,9.8
+Grand Est,3,Services,33,23.1
+Grand Est,3,Soft Skills,45,31.5
+Grand Est,3,Sécurité,5,3.5
+Grand Est,3,Tech/Digital,11,7.7
+Grand Est,4,Autre,30,21.0
+Grand Est,4,Commerce/Gestion,17,11.9
+Grand Est,4,Industrie,15,10.5
+Grand Est,4,Juridique,3,2.1
+Grand Est,4,Langues,4,2.8
+Grand Est,4,Santé,10,7.0
+Grand Est,4,Services,25,17.5
+Grand Est,4,Soft Skills,35,24.5
+Grand Est,4,Sécurité,11,7.7
+Grand Est,4,Tech/Digital,7,4.9
+Grand Est,5,Autre,24,16.8
+Grand Est,5,Commerce/Gestion,7,4.9
+Grand Est,5,Industrie,7,4.9
+Grand Est,5,Juridique,4,2.8
+Grand Est,5,Langues,5,3.5
+Grand Est,5,Santé,7,4.9
+Grand Est,5,Services,17,11.9
+Grand Est,5,Soft Skills,20,14.0
+Grand Est,5,Sécurité,3,2.1
+Grand Est,5,Tech/Digital,7,4.9
+Grand Est,6,Autre,21,14.7
+Grand Est,6,Commerce/Gestion,8,5.6
+Grand Est,6,Industrie,12,8.4
+Grand Est,6,Juridique,1,0.7
+Grand Est,6,Langues,3,2.1
+Grand Est,6,Santé,11,7.7
+Grand Est,6,Services,11,7.7
+Grand Est,6,Soft Skills,10,7.0
+Grand Est,6,Sécurité,2,1.4
+Grand Est,6,Tech/Digital,4,2.8
+Grand Est,7,Autre,18,12.6
+Grand Est,7,Commerce/Gestion,8,5.6
+Grand Est,7,Industrie,9,6.3
+Grand Est,7,Langues,3,2.1
+Grand Est,7,Santé,7,4.9
+Grand Est,7,Services,6,4.2
+Grand Est,7,Soft Skills,8,5.6
+Grand Est,7,Sécurité,3,2.1
+Grand Est,7,Tech/Digital,6,4.2
+Grand Est,8,Autre,19,13.3
+Grand Est,8,Commerce/Gestion,5,3.5
+Grand Est,8,Industrie,3,2.1
+Grand Est,8,Juridique,1,0.7
+Grand Est,8,Langues,3,2.1
+Grand Est,8,Santé,3,2.1
+Grand Est,8,Services,8,5.6
+Grand Est,8,Soft Skills,12,8.4
+Grand Est,8,Sécurité,2,1.4
+Grand Est,8,Tech/Digital,2,1.4
+Grand Est,9,Autre,16,11.2
+Grand Est,9,Commerce/Gestion,3,2.1
+Grand Est,9,Industrie,4,2.8
+Grand Est,9,Juridique,1,0.7
+Grand Est,9,Langues,6,4.2
+Grand Est,9,Santé,6,4.2
+Grand Est,9,Services,1,0.7
+Grand Est,9,Soft Skills,7,4.9
+Grand Est,9,Sécurité,4,2.8
+Grand Est,9,Tech/Digital,6,4.2
+Grand Est,10,Autre,13,9.1
+Grand Est,10,Commerce/Gestion,7,4.9
+Grand Est,10,Industrie,3,2.1
+Grand Est,10,Juridique,2,1.4
+Grand Est,10,Langues,1,0.7
+Grand Est,10,Santé,6,4.2
+Grand Est,10,Services,3,2.1
+Grand Est,10,Soft Skills,3,2.1
+Grand Est,10,Sécurité,3,2.1
+Grand Est,10,Tech/Digital,1,0.7
+Guadeloupe,3,Autre,7,4.9
+Guadeloupe,3,Commerce/Gestion,1,0.7
+Guadeloupe,3,Industrie,1,0.7
+Guadeloupe,3,Santé,4,2.8
+Guadeloupe,3,Services,5,3.5
+Guadeloupe,3,Soft Skills,3,2.1
+Guadeloupe,3,Sécurité,1,0.7
+Guadeloupe,4,Autre,6,4.2
+Guadeloupe,4,Industrie,2,1.4
+Guadeloupe,4,Langues,2,1.4
+Guadeloupe,4,Services,1,0.7
+Guadeloupe,4,Soft Skills,2,1.4
+Guadeloupe,4,Sécurité,2,1.4
+Guadeloupe,5,Autre,5,3.5
+Guadeloupe,5,Santé,2,1.4
+Guadeloupe,5,Services,3,2.1
+Guadeloupe,5,Soft Skills,1,0.7
+Guadeloupe,6,Autre,2,1.4
+Guadeloupe,6,Services,5,3.5
+Guadeloupe,6,Soft Skills,2,1.4
+Guadeloupe,7,Autre,2,1.4
+Guadeloupe,7,Commerce/Gestion,4,2.8
+Guadeloupe,7,Langues,1,0.7
+Guadeloupe,7,Santé,1,0.7
+Guadeloupe,7,Services,2,1.4
+Guadeloupe,8,Autre,4,2.8
+Guadeloupe,8,Commerce/Gestion,1,0.7
+Guadeloupe,8,Industrie,1,0.7
+Guadeloupe,8,Santé,1,0.7
+Guadeloupe,8,Services,3,2.1
+Guadeloupe,9,Autre,4,2.8
+Guadeloupe,9,Commerce/Gestion,1,0.7
+Guadeloupe,9,Industrie,1,0.7
+Guadeloupe,9,Juridique,1,0.7
+Guadeloupe,9,Santé,2,1.4
+Guadeloupe,9,Services,1,0.7
+Guadeloupe,10,Autre,2,1.4
+Guadeloupe,10,Industrie,2,1.4
+Guyane,3,Autre,1,0.7
+Guyane,3,Commerce/Gestion,1,0.7
+Guyane,3,Industrie,3,2.1
+Guyane,3,Juridique,1,0.7
+Guyane,3,Santé,2,1.4
+Guyane,4,Autre,3,2.1
+Guyane,4,Services,2,1.4
+Guyane,5,Autre,1,0.7
+Guyane,5,Industrie,1,0.7
+Guyane,5,Soft Skills,2,1.4
+Guyane,6,Autre,1,0.7
+Guyane,6,Commerce/Gestion,1,0.7
+Guyane,7,Autre,2,1.4
+Guyane,7,Commerce/Gestion,1,0.7
+Guyane,7,Services,1,0.7
+Guyane,7,Soft Skills,1,0.7
+Guyane,8,Autre,2,1.4
+Guyane,8,Commerce/Gestion,2,1.4
+Guyane,8,Industrie,1,0.7
+Guyane,8,Services,1,0.7
+Guyane,8,Soft Skills,1,0.7
+Guyane,9,Autre,1,0.7
+Guyane,9,Services,1,0.7
+Hauts-de-France,3,Autre,37,25.9
+Hauts-de-France,3,Commerce/Gestion,19,13.3
+Hauts-de-France,3,Industrie,12,8.4
+Hauts-de-France,3,Juridique,1,0.7
+Hauts-de-France,3,Langues,7,4.9
+Hauts-de-France,3,Santé,13,9.1
+Hauts-de-France,3,Services,18,12.6
+Hauts-de-France,3,Soft Skills,46,32.2
+Hauts-de-France,3,Sécurité,8,5.6
+Hauts-de-France,3,Tech/Digital,6,4.2
+Hauts-de-France,4,Autre,38,26.6
+Hauts-de-France,4,Commerce/Gestion,9,6.3
+Hauts-de-France,4,Industrie,4,2.8
+Hauts-de-France,4,Juridique,5,3.5
+Hauts-de-France,4,Langues,4,2.8
+Hauts-de-France,4,Santé,9,6.3
+Hauts-de-France,4,Services,19,13.3
+Hauts-de-France,4,Soft Skills,25,17.5
+Hauts-de-France,4,Sécurité,1,0.7
+Hauts-de-France,4,Tech/Digital,11,7.7
+Hauts-de-France,5,Autre,22,15.4
+Hauts-de-France,5,Commerce/Gestion,13,9.1
+Hauts-de-France,5,Industrie,6,4.2
+Hauts-de-France,5,Juridique,5,3.5
+Hauts-de-France,5,Langues,2,1.4
+Hauts-de-France,5,Santé,9,6.3
+Hauts-de-France,5,Services,8,5.6
+Hauts-de-France,5,Soft Skills,13,9.1
+Hauts-de-France,5,Sécurité,3,2.1
+Hauts-de-France,5,Tech/Digital,9,6.3
+Hauts-de-France,6,Autre,18,12.6
+Hauts-de-France,6,Commerce/Gestion,7,4.9
+Hauts-de-France,6,Industrie,5,3.5
+Hauts-de-France,6,Juridique,2,1.4
+Hauts-de-France,6,Langues,2,1.4
+Hauts-de-France,6,Santé,5,3.5
+Hauts-de-France,6,Services,7,4.9
+Hauts-de-France,6,Soft Skills,24,16.8
+Hauts-de-France,6,Sécurité,4,2.8
+Hauts-de-France,6,Tech/Digital,6,4.2
+Hauts-de-France,7,Autre,18,12.6
+Hauts-de-France,7,Commerce/Gestion,4,2.8
+Hauts-de-France,7,Industrie,2,1.4
+Hauts-de-France,7,Juridique,4,2.8
+Hauts-de-France,7,Santé,9,6.3
+Hauts-de-France,7,Services,5,3.5
+Hauts-de-France,7,Soft Skills,14,9.8
+Hauts-de-France,7,Tech/Digital,3,2.1
+Hauts-de-France,8,Autre,13,9.1
+Hauts-de-France,8,Commerce/Gestion,3,2.1
+Hauts-de-France,8,Industrie,3,2.1
+Hauts-de-France,8,Santé,5,3.5
+Hauts-de-France,8,Services,4,2.8
+Hauts-de-France,8,Soft Skills,16,11.2
+Hauts-de-France,8,Sécurité,2,1.4
+Hauts-de-France,8,Tech/Digital,1,0.7
+Hauts-de-France,9,Autre,12,8.4
+Hauts-de-France,9,Commerce/Gestion,6,4.2
+Hauts-de-France,9,Industrie,4,2.8
+Hauts-de-France,9,Juridique,1,0.7
+Hauts-de-France,9,Langues,2,1.4
+Hauts-de-France,9,Santé,3,2.1
+Hauts-de-France,9,Services,2,1.4
+Hauts-de-France,9,Soft Skills,8,5.6
+Hauts-de-France,9,Sécurité,5,3.5
+Hauts-de-France,9,Tech/Digital,2,1.4
+Hauts-de-France,10,Autre,9,6.3
+Hauts-de-France,10,Commerce/Gestion,2,1.4
+Hauts-de-France,10,Industrie,8,5.6
+Hauts-de-France,10,Juridique,1,0.7
+Hauts-de-France,10,Santé,2,1.4
+Hauts-de-France,10,Services,8,5.6
+Hauts-de-France,10,Soft Skills,5,3.5
+Hauts-de-France,10,Sécurité,4,2.8
+Hauts-de-France,10,Tech/Digital,1,0.7
+La Réunion,3,Autre,7,4.9
+La Réunion,3,Commerce/Gestion,10,7.0
+La Réunion,3,Industrie,3,2.1
+La Réunion,3,Langues,2,1.4
+La Réunion,3,Santé,3,2.1
+La Réunion,3,Services,7,4.9
+La Réunion,3,Soft Skills,8,5.6
+La Réunion,3,Sécurité,1,0.7
+La Réunion,4,Autre,11,7.7
+La Réunion,4,Commerce/Gestion,7,4.9
+La Réunion,4,Industrie,2,1.4
+La Réunion,4,Juridique,1,0.7
+La Réunion,4,Langues,2,1.4
+La Réunion,4,Santé,2,1.4
+La Réunion,4,Services,3,2.1
+La Réunion,4,Soft Skills,3,2.1
+La Réunion,4,Sécurité,3,2.1
+La Réunion,5,Autre,7,4.9
+La Réunion,5,Commerce/Gestion,4,2.8
+La Réunion,5,Industrie,3,2.1
+La Réunion,5,Juridique,1,0.7
+La Réunion,5,Langues,1,0.7
+La Réunion,5,Services,6,4.2
+La Réunion,5,Soft Skills,4,2.8
+La Réunion,5,Sécurité,1,0.7
+La Réunion,6,Autre,7,4.9
+La Réunion,6,Commerce/Gestion,1,0.7
+La Réunion,6,Industrie,1,0.7
+La Réunion,6,Juridique,1,0.7
+La Réunion,6,Langues,1,0.7
+La Réunion,6,Santé,3,2.1
+La Réunion,6,Services,4,2.8
+La Réunion,6,Soft Skills,2,1.4
+La Réunion,6,Sécurité,1,0.7
+La Réunion,7,Autre,3,2.1
+La Réunion,7,Commerce/Gestion,1,0.7
+La Réunion,7,Industrie,1,0.7
+La Réunion,7,Langues,2,1.4
+La Réunion,7,Santé,1,0.7
+La Réunion,7,Services,5,3.5
+La Réunion,7,Soft Skills,3,2.1
+La Réunion,8,Autre,3,2.1
+La Réunion,8,Commerce/Gestion,4,2.8
+La Réunion,8,Industrie,2,1.4
+La Réunion,8,Langues,1,0.7
+La Réunion,8,Services,4,2.8
+La Réunion,8,Soft Skills,4,2.8
+La Réunion,8,Sécurité,1,0.7
+La Réunion,9,Autre,3,2.1
+La Réunion,9,Commerce/Gestion,2,1.4
+La Réunion,9,Services,3,2.1
+La Réunion,9,Soft Skills,3,2.1
+La Réunion,9,Sécurité,2,1.4
+La Réunion,10,Autre,3,2.1
+La Réunion,10,Commerce/Gestion,3,2.1
+La Réunion,10,Industrie,2,1.4
+La Réunion,10,Langues,1,0.7
+La Réunion,10,Santé,2,1.4
+La Réunion,10,Soft Skills,2,1.4
+Martinique,3,Autre,3,2.1
+Martinique,3,Commerce/Gestion,2,1.4
+Martinique,3,Industrie,1,0.7
+Martinique,3,Juridique,1,0.7
+Martinique,3,Santé,1,0.7
+Martinique,3,Services,4,2.8
+Martinique,3,Soft Skills,3,2.1
+Martinique,3,Sécurité,1,0.7
+Martinique,4,Autre,5,3.5
+Martinique,4,Commerce/Gestion,3,2.1
+Martinique,4,Industrie,3,2.1
+Martinique,4,Santé,1,0.7
+Martinique,4,Services,3,2.1
+Martinique,4,Soft Skills,2,1.4
+Martinique,4,Sécurité,1,0.7
+Martinique,5,Autre,7,4.9
+Martinique,5,Industrie,1,0.7
+Martinique,5,Services,4,2.8
+Martinique,5,Soft Skills,2,1.4
+Martinique,6,Autre,6,4.2
+Martinique,6,Commerce/Gestion,1,0.7
+Martinique,6,Industrie,1,0.7
+Martinique,6,Santé,2,1.4
+Martinique,6,Services,1,0.7
+Martinique,6,Soft Skills,1,0.7
+Martinique,7,Autre,1,0.7
+Martinique,7,Industrie,1,0.7
+Martinique,7,Juridique,1,0.7
+Martinique,7,Services,1,0.7
+Martinique,8,Autre,1,0.7
+Martinique,8,Commerce/Gestion,1,0.7
+Martinique,8,Services,4,2.8
+Martinique,9,Autre,1,0.7
+Martinique,9,Commerce/Gestion,1,0.7
+Martinique,9,Industrie,1,0.7
+Martinique,9,Santé,2,1.4
+Martinique,9,Soft Skills,1,0.7
+Martinique,9,Sécurité,1,0.7
+Martinique,10,Autre,1,0.7
+Martinique,10,Juridique,2,1.4
+Martinique,10,Langues,1,0.7
+Martinique,10,Services,2,1.4
+Martinique,10,Soft Skills,2,1.4
+Mayotte,3,Autre,3,2.1
+Mayotte,3,Santé,1,0.7
+Mayotte,4,Autre,1,0.7
+Mayotte,4,Industrie,1,0.7
+Mayotte,4,Juridique,1,0.7
+Mayotte,4,Santé,1,0.7
+Mayotte,4,Services,1,0.7
+Mayotte,4,Soft Skills,2,1.4
+Mayotte,5,Autre,1,0.7
+Mayotte,5,Commerce/Gestion,3,2.1
+Mayotte,5,Industrie,1,0.7
+Mayotte,5,Services,1,0.7
+Mayotte,5,Sécurité,1,0.7
+Mayotte,6,Services,1,0.7
+Mayotte,6,Soft Skills,1,0.7
+Mayotte,7,Autre,1,0.7
+Mayotte,8,Autre,1,0.7
+Mayotte,8,Juridique,1,0.7
+Mayotte,8,Santé,2,1.4
+Mayotte,8,Soft Skills,1,0.7
+Mayotte,9,Services,1,0.7
+Mayotte,9,Soft Skills,2,1.4
+Mayotte,10,Autre,1,0.7
+Normandie,3,Autre,21,14.7
+Normandie,3,Commerce/Gestion,8,5.6
+Normandie,3,Industrie,2,1.4
+Normandie,3,Juridique,1,0.7
+Normandie,3,Langues,2,1.4
+Normandie,3,Santé,5,3.5
+Normandie,3,Services,13,9.1
+Normandie,3,Soft Skills,33,23.1
+Normandie,3,Sécurité,2,1.4
+Normandie,3,Tech/Digital,5,3.5
+Normandie,4,Autre,21,14.7
+Normandie,4,Commerce/Gestion,4,2.8
+Normandie,4,Industrie,5,3.5
+Normandie,4,Juridique,1,0.7
+Normandie,4,Langues,4,2.8
+Normandie,4,Santé,3,2.1
+Normandie,4,Services,7,4.9
+Normandie,4,Soft Skills,27,18.9
+Normandie,4,Sécurité,4,2.8
+Normandie,4,Tech/Digital,4,2.8
+Normandie,5,Autre,12,8.4
+Normandie,5,Commerce/Gestion,8,5.6
+Normandie,5,Industrie,4,2.8
+Normandie,5,Juridique,1,0.7
+Normandie,5,Langues,1,0.7
+Normandie,5,Santé,2,1.4
+Normandie,5,Services,9,6.3
+Normandie,5,Soft Skills,14,9.8
+Normandie,5,Tech/Digital,1,0.7
+Normandie,6,Autre,8,5.6
+Normandie,6,Commerce/Gestion,3,2.1
+Normandie,6,Industrie,2,1.4
+Normandie,6,Langues,3,2.1
+Normandie,6,Santé,3,2.1
+Normandie,6,Services,5,3.5
+Normandie,6,Soft Skills,7,4.9
+Normandie,6,Sécurité,3,2.1
+Normandie,6,Tech/Digital,2,1.4
+Normandie,7,Autre,9,6.3
+Normandie,7,Commerce/Gestion,1,0.7
+Normandie,7,Industrie,1,0.7
+Normandie,7,Langues,3,2.1
+Normandie,7,Santé,5,3.5
+Normandie,7,Services,7,4.9
+Normandie,7,Soft Skills,6,4.2
+Normandie,7,Sécurité,3,2.1
+Normandie,7,Tech/Digital,1,0.7
+Normandie,8,Autre,9,6.3
+Normandie,8,Commerce/Gestion,5,3.5
+Normandie,8,Industrie,2,1.4
+Normandie,8,Juridique,1,0.7
+Normandie,8,Santé,3,2.1
+Normandie,8,Services,4,2.8
+Normandie,8,Soft Skills,8,5.6
+Normandie,8,Sécurité,2,1.4
+Normandie,8,Tech/Digital,1,0.7
+Normandie,9,Autre,8,5.6
+Normandie,9,Commerce/Gestion,3,2.1
+Normandie,9,Industrie,4,2.8
+Normandie,9,Juridique,2,1.4
+Normandie,9,Langues,1,0.7
+Normandie,9,Santé,2,1.4
+Normandie,9,Services,3,2.1
+Normandie,9,Soft Skills,5,3.5
+Normandie,9,Tech/Digital,1,0.7
+Normandie,10,Autre,8,5.6
+Normandie,10,Commerce/Gestion,2,1.4
+Normandie,10,Industrie,1,0.7
+Normandie,10,Juridique,1,0.7
+Normandie,10,Langues,1,0.7
+Normandie,10,Santé,4,2.8
+Normandie,10,Services,1,0.7
+Normandie,10,Soft Skills,4,2.8
+Normandie,10,Sécurité,1,0.7
+Nouvelle-Aquitaine,3,Autre,48,33.6
+Nouvelle-Aquitaine,3,Commerce/Gestion,20,14.0
+Nouvelle-Aquitaine,3,Industrie,15,10.5
+Nouvelle-Aquitaine,3,Juridique,6,4.2
+Nouvelle-Aquitaine,3,Langues,6,4.2
+Nouvelle-Aquitaine,3,Santé,22,15.4
+Nouvelle-Aquitaine,3,Services,24,16.8
+Nouvelle-Aquitaine,3,Soft Skills,51,35.7
+Nouvelle-Aquitaine,3,Sécurité,7,4.9
+Nouvelle-Aquitaine,3,Tech/Digital,10,7.0
+Nouvelle-Aquitaine,4,Autre,58,40.6
+Nouvelle-Aquitaine,4,Commerce/Gestion,18,12.6
+Nouvelle-Aquitaine,4,Industrie,10,7.0
+Nouvelle-Aquitaine,4,Juridique,1,0.7
+Nouvelle-Aquitaine,4,Langues,7,4.9
+Nouvelle-Aquitaine,4,Santé,13,9.1
+Nouvelle-Aquitaine,4,Services,27,18.9
+Nouvelle-Aquitaine,4,Soft Skills,48,33.6
+Nouvelle-Aquitaine,4,Sécurité,2,1.4
+Nouvelle-Aquitaine,4,Tech/Digital,15,10.5
+Nouvelle-Aquitaine,5,Autre,36,25.2
+Nouvelle-Aquitaine,5,Commerce/Gestion,9,6.3
+Nouvelle-Aquitaine,5,Industrie,12,8.4
+Nouvelle-Aquitaine,5,Juridique,3,2.1
+Nouvelle-Aquitaine,5,Langues,5,3.5
+Nouvelle-Aquitaine,5,Santé,12,8.4
+Nouvelle-Aquitaine,5,Services,11,7.7
+Nouvelle-Aquitaine,5,Soft Skills,31,21.7
+Nouvelle-Aquitaine,5,Sécurité,6,4.2
+Nouvelle-Aquitaine,5,Tech/Digital,9,6.3
+Nouvelle-Aquitaine,6,Autre,30,21.0
+Nouvelle-Aquitaine,6,Commerce/Gestion,10,7.0
+Nouvelle-Aquitaine,6,Industrie,9,6.3
+Nouvelle-Aquitaine,6,Juridique,2,1.4
+Nouvelle-Aquitaine,6,Langues,7,4.9
+Nouvelle-Aquitaine,6,Santé,10,7.0
+Nouvelle-Aquitaine,6,Services,12,8.4
+Nouvelle-Aquitaine,6,Soft Skills,29,20.3
+Nouvelle-Aquitaine,6,Sécurité,2,1.4
+Nouvelle-Aquitaine,6,Tech/Digital,9,6.3
+Nouvelle-Aquitaine,7,Autre,25,17.5
+Nouvelle-Aquitaine,7,Commerce/Gestion,9,6.3
+Nouvelle-Aquitaine,7,Industrie,8,5.6
+Nouvelle-Aquitaine,7,Juridique,2,1.4
+Nouvelle-Aquitaine,7,Langues,1,0.7
+Nouvelle-Aquitaine,7,Santé,4,2.8
+Nouvelle-Aquitaine,7,Services,9,6.3
+Nouvelle-Aquitaine,7,Soft Skills,22,15.4
+Nouvelle-Aquitaine,7,Sécurité,2,1.4
+Nouvelle-Aquitaine,7,Tech/Digital,7,4.9
+Nouvelle-Aquitaine,8,Autre,24,16.8
+Nouvelle-Aquitaine,8,Commerce/Gestion,6,4.2
+Nouvelle-Aquitaine,8,Industrie,8,5.6
+Nouvelle-Aquitaine,8,Juridique,1,0.7
+Nouvelle-Aquitaine,8,Langues,4,2.8
+Nouvelle-Aquitaine,8,Santé,12,8.4
+Nouvelle-Aquitaine,8,Services,6,4.2
+Nouvelle-Aquitaine,8,Soft Skills,16,11.2
+Nouvelle-Aquitaine,8,Sécurité,5,3.5
+Nouvelle-Aquitaine,8,Tech/Digital,3,2.1
+Nouvelle-Aquitaine,9,Autre,19,13.3
+Nouvelle-Aquitaine,9,Commerce/Gestion,5,3.5
+Nouvelle-Aquitaine,9,Industrie,2,1.4
+Nouvelle-Aquitaine,9,Juridique,1,0.7
+Nouvelle-Aquitaine,9,Langues,5,3.5
+Nouvelle-Aquitaine,9,Santé,9,6.3
+Nouvelle-Aquitaine,9,Services,7,4.9
+Nouvelle-Aquitaine,9,Soft Skills,6,4.2
+Nouvelle-Aquitaine,9,Sécurité,2,1.4
+Nouvelle-Aquitaine,9,Tech/Digital,3,2.1
+Nouvelle-Aquitaine,10,Autre,12,8.4
+Nouvelle-Aquitaine,10,Commerce/Gestion,9,6.3
+Nouvelle-Aquitaine,10,Industrie,6,4.2
+Nouvelle-Aquitaine,10,Juridique,1,0.7
+Nouvelle-Aquitaine,10,Langues,2,1.4
+Nouvelle-Aquitaine,10,Santé,7,4.9
+Nouvelle-Aquitaine,10,Services,7,4.9
+Nouvelle-Aquitaine,10,Soft Skills,12,8.4
+Nouvelle-Aquitaine,10,Sécurité,3,2.1
+Nouvelle-Aquitaine,10,Tech/Digital,1,0.7
+Occitanie,3,Autre,78,54.6
+Occitanie,3,Commerce/Gestion,27,18.9
+Occitanie,3,Industrie,20,14.0
+Occitanie,3,Juridique,4,2.8
+Occitanie,3,Langues,8,5.6
+Occitanie,3,Santé,31,21.7
+Occitanie,3,Services,27,18.9
+Occitanie,3,Soft Skills,52,36.4
+Occitanie,3,Sécurité,4,2.8
+Occitanie,3,Tech/Digital,28,19.6
+Occitanie,4,Autre,59,41.3
+Occitanie,4,Commerce/Gestion,23,16.1
+Occitanie,4,Industrie,16,11.2
+Occitanie,4,Juridique,5,3.5
+Occitanie,4,Langues,6,4.2
+Occitanie,4,Santé,21,14.7
+Occitanie,4,Services,24,16.8
+Occitanie,4,Soft Skills,45,31.5
+Occitanie,4,Sécurité,6,4.2
+Occitanie,4,Tech/Digital,16,11.2
+Occitanie,5,Autre,49,34.3
+Occitanie,5,Commerce/Gestion,13,9.1
+Occitanie,5,Industrie,11,7.7
+Occitanie,5,Juridique,6,4.2
+Occitanie,5,Langues,12,8.4
+Occitanie,5,Santé,14,9.8
+Occitanie,5,Services,17,11.9
+Occitanie,5,Soft Skills,31,21.7
+Occitanie,5,Sécurité,2,1.4
+Occitanie,5,Tech/Digital,10,7.0
+Occitanie,6,Autre,30,21.0
+Occitanie,6,Commerce/Gestion,15,10.5
+Occitanie,6,Industrie,9,6.3
+Occitanie,6,Juridique,2,1.4
+Occitanie,6,Langues,5,3.5
+Occitanie,6,Santé,14,9.8
+Occitanie,6,Services,21,14.7
+Occitanie,6,Soft Skills,26,18.2
+Occitanie,6,Sécurité,3,2.1
+Occitanie,6,Tech/Digital,7,4.9
+Occitanie,7,Autre,40,28.0
+Occitanie,7,Commerce/Gestion,9,6.3
+Occitanie,7,Industrie,5,3.5
+Occitanie,7,Juridique,5,3.5
+Occitanie,7,Langues,7,4.9
+Occitanie,7,Santé,7,4.9
+Occitanie,7,Services,18,12.6
+Occitanie,7,Soft Skills,17,11.9
+Occitanie,7,Sécurité,2,1.4
+Occitanie,7,Tech/Digital,5,3.5
+Occitanie,8,Autre,26,18.2
+Occitanie,8,Commerce/Gestion,13,9.1
+Occitanie,8,Industrie,6,4.2
+Occitanie,8,Juridique,1,0.7
+Occitanie,8,Langues,4,2.8
+Occitanie,8,Santé,7,4.9
+Occitanie,8,Services,5,3.5
+Occitanie,8,Soft Skills,16,11.2
+Occitanie,8,Sécurité,2,1.4
+Occitanie,8,Tech/Digital,5,3.5
+Occitanie,9,Autre,24,16.8
+Occitanie,9,Commerce/Gestion,8,5.6
+Occitanie,9,Industrie,7,4.9
+Occitanie,9,Juridique,1,0.7
+Occitanie,9,Langues,9,6.3
+Occitanie,9,Santé,9,6.3
+Occitanie,9,Services,14,9.8
+Occitanie,9,Soft Skills,15,10.5
+Occitanie,9,Sécurité,3,2.1
+Occitanie,9,Tech/Digital,4,2.8
+Occitanie,10,Autre,22,15.4
+Occitanie,10,Commerce/Gestion,9,6.3
+Occitanie,10,Industrie,6,4.2
+Occitanie,10,Juridique,2,1.4
+Occitanie,10,Langues,5,3.5
+Occitanie,10,Santé,8,5.6
+Occitanie,10,Services,3,2.1
+Occitanie,10,Soft Skills,16,11.2
+Occitanie,10,Sécurité,1,0.7
+Occitanie,10,Tech/Digital,4,2.8
+Pays de la Loire,3,Autre,35,24.5
+Pays de la Loire,3,Commerce/Gestion,17,11.9
+Pays de la Loire,3,Industrie,14,9.8
+Pays de la Loire,3,Langues,5,3.5
+Pays de la Loire,3,Santé,8,5.6
+Pays de la Loire,3,Services,20,14.0
+Pays de la Loire,3,Soft Skills,30,21.0
+Pays de la Loire,3,Sécurité,4,2.8
+Pays de la Loire,3,Tech/Digital,14,9.8
+Pays de la Loire,4,Autre,22,15.4
+Pays de la Loire,4,Commerce/Gestion,15,10.5
+Pays de la Loire,4,Industrie,14,9.8
+Pays de la Loire,4,Juridique,3,2.1
+Pays de la Loire,4,Langues,2,1.4
+Pays de la Loire,4,Santé,6,4.2
+Pays de la Loire,4,Services,16,11.2
+Pays de la Loire,4,Soft Skills,26,18.2
+Pays de la Loire,4,Sécurité,1,0.7
+Pays de la Loire,4,Tech/Digital,8,5.6
+Pays de la Loire,5,Autre,24,16.8
+Pays de la Loire,5,Commerce/Gestion,4,2.8
+Pays de la Loire,5,Industrie,10,7.0
+Pays de la Loire,5,Langues,2,1.4
+Pays de la Loire,5,Santé,8,5.6
+Pays de la Loire,5,Services,13,9.1
+Pays de la Loire,5,Soft Skills,20,14.0
+Pays de la Loire,5,Sécurité,2,1.4
+Pays de la Loire,5,Tech/Digital,12,8.4
+Pays de la Loire,6,Autre,17,11.9
+Pays de la Loire,6,Commerce/Gestion,7,4.9
+Pays de la Loire,6,Industrie,7,4.9
+Pays de la Loire,6,Juridique,1,0.7
+Pays de la Loire,6,Langues,2,1.4
+Pays de la Loire,6,Santé,6,4.2
+Pays de la Loire,6,Services,7,4.9
+Pays de la Loire,6,Soft Skills,15,10.5
+Pays de la Loire,6,Sécurité,2,1.4
+Pays de la Loire,6,Tech/Digital,5,3.5
+Pays de la Loire,7,Autre,12,8.4
+Pays de la Loire,7,Commerce/Gestion,6,4.2
+Pays de la Loire,7,Industrie,6,4.2
+Pays de la Loire,7,Juridique,1,0.7
+Pays de la Loire,7,Langues,4,2.8
+Pays de la Loire,7,Santé,7,4.9
+Pays de la Loire,7,Services,4,2.8
+Pays de la Loire,7,Soft Skills,9,6.3
+Pays de la Loire,7,Tech/Digital,3,2.1
+Pays de la Loire,8,Autre,17,11.9
+Pays de la Loire,8,Commerce/Gestion,2,1.4
+Pays de la Loire,8,Industrie,6,4.2
+Pays de la Loire,8,Juridique,1,0.7
+Pays de la Loire,8,Langues,3,2.1
+Pays de la Loire,8,Santé,3,2.1
+Pays de la Loire,8,Services,2,1.4
+Pays de la Loire,8,Soft Skills,12,8.4
+Pays de la Loire,8,Sécurité,2,1.4
+Pays de la Loire,8,Tech/Digital,4,2.8
+Pays de la Loire,9,Autre,15,10.5
+Pays de la Loire,9,Commerce/Gestion,2,1.4
+Pays de la Loire,9,Industrie,11,7.7
+Pays de la Loire,9,Juridique,2,1.4
+Pays de la Loire,9,Langues,3,2.1
+Pays de la Loire,9,Santé,5,3.5
+Pays de la Loire,9,Services,6,4.2
+Pays de la Loire,9,Soft Skills,4,2.8
+Pays de la Loire,9,Sécurité,2,1.4
+Pays de la Loire,9,Tech/Digital,1,0.7
+Pays de la Loire,10,Autre,14,9.8
+Pays de la Loire,10,Commerce/Gestion,6,4.2
+Pays de la Loire,10,Industrie,6,4.2
+Pays de la Loire,10,Santé,4,2.8
+Pays de la Loire,10,Services,7,4.9
+Pays de la Loire,10,Soft Skills,5,3.5
+Pays de la Loire,10,Sécurité,4,2.8
+Pays de la Loire,10,Tech/Digital,4,2.8
+Provence-Alpes-Côte d'Azur,3,Autre,58,40.6
+Provence-Alpes-Côte d'Azur,3,Commerce/Gestion,25,17.5
+Provence-Alpes-Côte d'Azur,3,Industrie,16,11.2
+Provence-Alpes-Côte d'Azur,3,Juridique,6,4.2
+Provence-Alpes-Côte d'Azur,3,Langues,12,8.4
+Provence-Alpes-Côte d'Azur,3,Santé,25,17.5
+Provence-Alpes-Côte d'Azur,3,Services,26,18.2
+Provence-Alpes-Côte d'Azur,3,Soft Skills,63,44.1
+Provence-Alpes-Côte d'Azur,3,Sécurité,7,4.9
+Provence-Alpes-Côte d'Azur,3,Tech/Digital,20,14.0
+Provence-Alpes-Côte d'Azur,4,Autre,53,37.1
+Provence-Alpes-Côte d'Azur,4,Commerce/Gestion,23,16.1
+Provence-Alpes-Côte d'Azur,4,Industrie,6,4.2
+Provence-Alpes-Côte d'Azur,4,Juridique,7,4.9
+Provence-Alpes-Côte d'Azur,4,Langues,11,7.7
+Provence-Alpes-Côte d'Azur,4,Santé,16,11.2
+Provence-Alpes-Côte d'Azur,4,Services,26,18.2
+Provence-Alpes-Côte d'Azur,4,Soft Skills,46,32.2
+Provence-Alpes-Côte d'Azur,4,Sécurité,5,3.5
+Provence-Alpes-Côte d'Azur,4,Tech/Digital,6,4.2
+Provence-Alpes-Côte d'Azur,5,Autre,46,32.2
+Provence-Alpes-Côte d'Azur,5,Commerce/Gestion,14,9.8
+Provence-Alpes-Côte d'Azur,5,Industrie,5,3.5
+Provence-Alpes-Côte d'Azur,5,Juridique,4,2.8
+Provence-Alpes-Côte d'Azur,5,Langues,11,7.7
+Provence-Alpes-Côte d'Azur,5,Santé,13,9.1
+Provence-Alpes-Côte d'Azur,5,Services,16,11.2
+Provence-Alpes-Côte d'Azur,5,Soft Skills,43,30.1
+Provence-Alpes-Côte d'Azur,5,Sécurité,7,4.9
+Provence-Alpes-Côte d'Azur,5,Tech/Digital,8,5.6
+Provence-Alpes-Côte d'Azur,6,Autre,30,21.0
+Provence-Alpes-Côte d'Azur,6,Commerce/Gestion,8,5.6
+Provence-Alpes-Côte d'Azur,6,Industrie,13,9.1
+Provence-Alpes-Côte d'Azur,6,Juridique,3,2.1
+Provence-Alpes-Côte d'Azur,6,Langues,8,5.6
+Provence-Alpes-Côte d'Azur,6,Santé,15,10.5
+Provence-Alpes-Côte d'Azur,6,Services,19,13.3
+Provence-Alpes-Côte d'Azur,6,Soft Skills,24,16.8
+Provence-Alpes-Côte d'Azur,6,Sécurité,4,2.8
+Provence-Alpes-Côte d'Azur,6,Tech/Digital,5,3.5
+Provence-Alpes-Côte d'Azur,7,Autre,22,15.4
+Provence-Alpes-Côte d'Azur,7,Commerce/Gestion,11,7.7
+Provence-Alpes-Côte d'Azur,7,Juridique,3,2.1
+Provence-Alpes-Côte d'Azur,7,Langues,3,2.1
+Provence-Alpes-Côte d'Azur,7,Santé,10,7.0
+Provence-Alpes-Côte d'Azur,7,Services,13,9.1
+Provence-Alpes-Côte d'Azur,7,Soft Skills,12,8.4
+Provence-Alpes-Côte d'Azur,7,Sécurité,6,4.2
+Provence-Alpes-Côte d'Azur,7,Tech/Digital,7,4.9
+Provence-Alpes-Côte d'Azur,8,Autre,19,13.3
+Provence-Alpes-Côte d'Azur,8,Commerce/Gestion,9,6.3
+Provence-Alpes-Côte d'Azur,8,Industrie,5,3.5
+Provence-Alpes-Côte d'Azur,8,Juridique,2,1.4
+Provence-Alpes-Côte d'Azur,8,Langues,9,6.3
+Provence-Alpes-Côte d'Azur,8,Santé,13,9.1
+Provence-Alpes-Côte d'Azur,8,Services,10,7.0
+Provence-Alpes-Côte d'Azur,8,Soft Skills,11,7.7
+Provence-Alpes-Côte d'Azur,8,Sécurité,2,1.4
+Provence-Alpes-Côte d'Azur,8,Tech/Digital,4,2.8
+Provence-Alpes-Côte d'Azur,9,Autre,26,18.2
+Provence-Alpes-Côte d'Azur,9,Commerce/Gestion,9,6.3
+Provence-Alpes-Côte d'Azur,9,Industrie,3,2.1
+Provence-Alpes-Côte d'Azur,9,Juridique,2,1.4
+Provence-Alpes-Côte d'Azur,9,Langues,5,3.5
+Provence-Alpes-Côte d'Azur,9,Santé,7,4.9
+Provence-Alpes-Côte d'Azur,9,Services,4,2.8
+Provence-Alpes-Côte d'Azur,9,Soft Skills,7,4.9
+Provence-Alpes-Côte d'Azur,9,Sécurité,5,3.5
+Provence-Alpes-Côte d'Azur,9,Tech/Digital,6,4.2
+Provence-Alpes-Côte d'Azur,10,Autre,21,14.7
+Provence-Alpes-Côte d'Azur,10,Commerce/Gestion,7,4.9
+Provence-Alpes-Côte d'Azur,10,Industrie,3,2.1
+Provence-Alpes-Côte d'Azur,10,Juridique,1,0.7
+Provence-Alpes-Côte d'Azur,10,Langues,7,4.9
+Provence-Alpes-Côte d'Azur,10,Santé,10,7.0
+Provence-Alpes-Côte d'Azur,10,Services,7,4.9
+Provence-Alpes-Côte d'Azur,10,Soft Skills,12,8.4
+Provence-Alpes-Côte d'Azur,10,Sécurité,3,2.1
+Provence-Alpes-Côte d'Azur,10,Tech/Digital,6,4.2
+Île-de-France,3,Autre,234,163.8
+Île-de-France,3,Commerce/Gestion,74,51.8
+Île-de-France,3,Industrie,46,32.2
+Île-de-France,3,Juridique,13,9.1
+Île-de-France,3,Langues,34,23.8
+Île-de-France,3,Santé,45,31.5
+Île-de-France,3,Services,75,52.5
+Île-de-France,3,Soft Skills,213,149.1
+Île-de-France,3,Sécurité,13,9.1
+Île-de-France,3,Tech/Digital,62,43.4
+Île-de-France,4,Autre,199,139.3
+Île-de-France,4,Commerce/Gestion,66,46.2
+Île-de-France,4,Industrie,37,25.9
+Île-de-France,4,Juridique,16,11.2
+Île-de-France,4,Langues,22,15.4
+Île-de-France,4,Santé,41,28.7
+Île-de-France,4,Services,83,58.1
+Île-de-France,4,Soft Skills,190,133.0
+Île-de-France,4,Sécurité,10,7.0
+Île-de-France,4,Tech/Digital,48,33.6
+Île-de-France,5,Autre,118,82.6
+Île-de-France,5,Commerce/Gestion,45,31.5
+Île-de-France,5,Industrie,36,25.2
+Île-de-France,5,Juridique,14,9.8
+Île-de-France,5,Langues,20,14.0
+Île-de-France,5,Santé,40,28.0
+Île-de-France,5,Services,67,46.9
+Île-de-France,5,Soft Skills,142,99.4
+Île-de-France,5,Sécurité,13,9.1
+Île-de-France,5,Tech/Digital,37,25.9
+Île-de-France,6,Autre,122,85.4
+Île-de-France,6,Commerce/Gestion,42,29.4
+Île-de-France,6,Industrie,18,12.6
+Île-de-France,6,Juridique,15,10.5
+Île-de-France,6,Langues,21,14.7
+Île-de-France,6,Santé,37,25.9
+Île-de-France,6,Services,40,28.0
+Île-de-France,6,Soft Skills,101,70.7
+Île-de-France,6,Sécurité,6,4.2
+Île-de-France,6,Tech/Digital,29,20.3
+Île-de-France,7,Autre,90,63.0
+Île-de-France,7,Commerce/Gestion,24,16.8
+Île-de-France,7,Industrie,20,14.0
+Île-de-France,7,Juridique,12,8.4
+Île-de-France,7,Langues,16,11.2
+Île-de-France,7,Santé,23,16.1
+Île-de-France,7,Services,26,18.2
+Île-de-France,7,Soft Skills,65,45.5
+Île-de-France,7,Sécurité,14,9.8
+Île-de-France,7,Tech/Digital,22,15.4
+Île-de-France,8,Autre,88,61.6
+Île-de-France,8,Commerce/Gestion,27,18.9
+Île-de-France,8,Industrie,18,12.6
+Île-de-France,8,Juridique,5,3.5
+Île-de-France,8,Langues,13,9.1
+Île-de-France,8,Santé,26,18.2
+Île-de-France,8,Services,24,16.8
+Île-de-France,8,Soft Skills,66,46.2
+Île-de-France,8,Sécurité,2,1.4
+Île-de-France,8,Tech/Digital,18,12.6
+Île-de-France,9,Autre,52,36.4
+Île-de-France,9,Commerce/Gestion,25,17.5
+Île-de-France,9,Industrie,19,13.3
+Île-de-France,9,Juridique,6,4.2
+Île-de-France,9,Langues,10,7.0
+Île-de-France,9,Santé,23,16.1
+Île-de-France,9,Services,15,10.5
+Île-de-France,9,Soft Skills,40,28.0
+Île-de-France,9,Sécurité,6,4.2
+Île-de-France,9,Tech/Digital,15,10.5
+Île-de-France,10,Autre,67,46.9
+Île-de-France,10,Commerce/Gestion,21,14.7
+Île-de-France,10,Industrie,12,8.4
+Île-de-France,10,Juridique,8,5.6
+Île-de-France,10,Langues,10,7.0
+Île-de-France,10,Santé,15,10.5
+Île-de-France,10,Services,18,12.6
+Île-de-France,10,Soft Skills,32,22.4
+Île-de-France,10,Sécurité,6,4.2
+Île-de-France,10,Tech/Digital,18,12.6

--- a/analysis_outputs/prompt18_tam_final.md
+++ b/analysis_outputs/prompt18_tam_final.md
@@ -1,0 +1,109 @@
+### Tableau 1 : Entonnoir TAM complet
+| Étape | OF | % base | % précédent |
+| --- | --- | --- | --- |
+| Base France | 154 107 | 100.00% | 100.00% |
+| 3-10 formateurs | 17 497 | 11.35% | 11.35% |
+| + Qualiopi certifiés | 12 435 | 8.07% | 71.07% |
+| + Actifs (>0 stag) | 12 303 | 7.98% | 98.94% |
+| + Production ≥5 livr. | 12 303 | 7.98% | 100.00% |
+| + Mindset tech (70%) | 8 612 | 5.59% | 70.00% |
+
+### Tableau 2 : Comparaison TAM théorique vs réel
+| Étape | Document 1 (théorique) | Calculé (réel) | Écart | Écart % |
+| --- | --- | --- | --- | --- |
+| TAM Base | 12 303 | 12 303 | +0 | 0.0% |
+| TAM Production (60%) | 7 381 | 12 303 | +4 922 | 66.7% |
+| TAM Final (×70%) | 5 167 | 8 612 | +3 445 | 66.7% |
+
+### Tableau 3 : TAM segmenté
+| Segment | TAM Base | TAM Prod | TAM Final | Priorité |
+| --- | --- | --- | --- | --- |
+| Prioritaire (4-5) | 4 227 | 4 227 | 2 959 | 🔴 HAUTE |
+| Secondaire (3, 6-10) | 8 076 | 8 076 | 5 653 | 🟠 MOYENNE |
+| TOTAL 3-10 | 12 303 | 12 303 | 8 612 | - |
+
+### Tableau 4 : TAM Final répartition géographique
+| Région | TAM Base | TAM Prod | TAM Final | % national |
+| --- | --- | --- | --- | --- |
+| Île-de-France | 3 501 | 3 501 | 2 451 | 28.5% |
+| Auvergne-Rhône-Alpes | 1 601 | 1 601 | 1 121 | 13.0% |
+| Occitanie | 1 167 | 1 167 | 817 | 9.5% |
+| Provence-Alpes-Côte d'Azur | 1 075 | 1 075 | 752 | 8.7% |
+| Nouvelle-Aquitaine | 955 | 955 | 668 | 7.8% |
+| Grand Est | 752 | 752 | 526 | 6.1% |
+| Hauts-de-France | 653 | 653 | 457 | 5.3% |
+| Pays de la Loire | 629 | 629 | 440 | 5.1% |
+| Bretagne | 468 | 468 | 328 | 3.8% |
+| Normandie | 383 | 383 | 268 | 3.1% |
+| Bourgogne-Franche-Comté | 335 | 335 | 234 | 2.7% |
+| Centre-Val de Loire | 306 | 306 | 214 | 2.5% |
+| La Réunion | 184 | 184 | 129 | 1.5% |
+| Guadeloupe | 91 | 91 | 64 | 0.7% |
+| Martinique | 85 | 85 | 59 | 0.7% |
+| Corse | 54 | 54 | 38 | 0.4% |
+| Guyane | 33 | 33 | 23 | 0.3% |
+| Mayotte | 30 | 30 | 21 | 0.2% |
+| Autres DOM-TOM | 1 | 1 | 1 | 0.0% |
+| TOTAL | 12 303 | 12 303 | 8 612 | 100.0% |
+
+### Tableau 5 : TAM Final par domaine
+| Macro-thème | TAM Final | % total | Priorité marketing |
+| --- | --- | --- | --- |
+| Soft Skills | 1 837 | 21.3% | HAUTE |
+| Tech/Digital | 531 | 6.2% | BASSE |
+| Commerce/Gestion | 823 | 9.6% | BASSE |
+| Santé | 718 | 8.3% | BASSE |
+| Langues | 365 | 4.2% | BASSE |
+| Juridique | 188 | 2.2% | BASSE |
+| Industrie | 625 | 7.3% | BASSE |
+| Services | 1 000 | 11.6% | MOYENNE |
+| Sécurité | 256 | 3.0% | BASSE |
+| Autre | 2 269 | 26.4% | MOYENNE |
+
+### Tableau 6 : Taux pénétration objectifs
+| Objectif | Clients nécessaires | TAM Final | Taux pénétration | Faisabilité |
+| --- | --- | --- | --- | --- |
+| 50K€/mois | 167 | 8 612 | 1.94% | ✅ Réaliste |
+| 100K€/mois | 334 | 8 612 | 3.88% | ⚠️ Ambitieux |
+| 150K€/mois | 502 | 8 612 | 5.83% | ⚠️ Difficile |
+| 200K€/mois | 669 | 8 612 | 7.77% | ⚠️ Difficile |
+
+### Tableau 7 : Options élargissement TAM
+| Option | Ajustement | TAM additionnel | TAM Final | Impact |
+| --- | --- | --- | --- | --- |
+| Actuel | Aucun | 0 | 8 612 | Impact limité |
+
+## Synthèse
+TAM FINAL QALIA : 8 612 OF
+
+Entonnoir complet :
+- Base France : 154 107 (100.00%)
+- 3-10 formateurs : 17 497 (11.35%)
+- + Qualiopi certifiés : 12 435 (8.07%)
+- + Actifs (>0 stag) : 12 303 (7.98%)
+- + Production ≥5 livr. : 12 303 (7.98%)
+- + Mindset tech (70%) : 8 612 (5.59%)
+
+vs Document 1 théorique (5 167) : +66.7%
+
+### Validation Avatar
+AVATAR V1 : ✅ VALIDÉ
+
+Hypothèses validées :
+- 3-10 formateurs : ✅ 17 497 OF
+- Qualiopi + actifs : ✅ 12 303 OF
+- Production 60% : ❌ 100% réel
+- Sweet spot : 3-10 formateurs
+
+TAM Final :
+- 8 612 OF (+66.7% vs doc)
+
+### Objectif 150K€ faisabilité
+OBJECTIF 150K€/MOIS : 502 clients → 5.83% du TAM
+FAISABILITÉ : M6 : ⚠️ Très difficile | M12 : ✅ Réaliste | M18 : ✅ Très réaliste
+
+### Segments prioritaires
+TOP 3 SEGMENTS (représentent 4.3% TAM Final) :
+1. [Île-de-France + 4 form + Autre] : 139 OF
+2. [Île-de-France + 4 form + Soft Skills] : 133 OF
+3. [Île-de-France + 5 form + Soft Skills] : 99 OF

--- a/prompt18_tam_final.py
+++ b/prompt18_tam_final.py
@@ -1,0 +1,341 @@
+import os
+from collections import Counter
+from typing import Dict, List, Tuple
+
+from prompt17_sweet_spot import MACRO_THEMES, REGION_NAMES, load_records
+
+OUTPUT_MD = os.path.join("analysis_outputs", "prompt18_tam_final.md")
+OUTPUT_CSV = os.path.join("analysis_outputs", "prompt18_tam_final.csv")
+
+MINDSET_FACTOR = 0.70
+PRODUCTION_THRESHOLD = 5.0
+
+def format_int(value: float) -> str:
+    return f"{int(round(value)):,}".replace(",", " ")
+
+def format_percent(value: float, decimals: int = 1) -> str:
+    return f"{value * 100:.{decimals}f}%"
+
+def build_stage_funnel(records) -> Tuple[List[Tuple[str, int, float, float]], Dict[str, List]]:
+    total_base = len(records)
+    stage1 = [r for r in records if r.effectif is not None and 3 <= r.effectif <= 10]
+    stage2 = [r for r in stage1 if r.qualiopi_actions is not None]
+    stage3 = [r for r in stage2 if r.nb_stagiaires > 0]
+    stage4 = [r for r in stage3 if (r.production_estimee or 0) >= PRODUCTION_THRESHOLD]
+    stage5_total = len(stage4) * MINDSET_FACTOR
+
+    funnel = [
+        ("Base France", total_base, 1.0, 1.0),
+        ("3-10 formateurs", len(stage1), len(stage1) / total_base if total_base else 0.0, len(stage1) / total_base if total_base else 0.0),
+        ("+ Qualiopi certifiés", len(stage2), len(stage2) / total_base if total_base else 0.0, len(stage2) / len(stage1) if stage1 else 0.0),
+        ("+ Actifs (>0 stag)", len(stage3), len(stage3) / total_base if total_base else 0.0, len(stage3) / len(stage2) if stage2 else 0.0),
+        ("+ Production ≥5 livr.", len(stage4), len(stage4) / total_base if total_base else 0.0, len(stage4) / len(stage3) if stage3 else 0.0),
+        ("+ Mindset tech (70%)", stage5_total, stage5_total / total_base if total_base else 0.0, stage5_total / len(stage4) if stage4 else 0.0),
+    ]
+
+    stages = {
+        "stage1": stage1,
+        "stage2": stage2,
+        "stage3": stage3,
+        "stage4": stage4,
+        "final_total": stage5_total,
+    }
+    return funnel, stages
+
+def table_markdown(headers: List[str], rows: List[List[str]]) -> str:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join(["---"] * len(headers)) + " |"]
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+def build_comparison_table(actual_base: int, actual_prod: int, final_total: float) -> str:
+    doc_base = 12303
+    doc_prod = 7381
+    doc_final = 5167
+    rows = []
+    def add_row(label: str, doc_value: int, actual_value: float):
+        diff = actual_value - doc_value
+        diff_pct = (diff / doc_value * 100) if doc_value else 0.0
+        rows.append([
+            label,
+            format_int(doc_value),
+            format_int(actual_value),
+            f"{diff:+,.0f}".replace(",", " "),
+            format_percent(diff_pct / 100.0, 1),
+        ])
+    add_row("TAM Base", doc_base, actual_base)
+    add_row("TAM Production (60%)", doc_prod, actual_prod)
+    add_row("TAM Final (×70%)", doc_final, final_total)
+    return table_markdown(["Étape", "Document 1 (théorique)", "Calculé (réel)", "Écart", "Écart %"], rows)
+
+def build_segment_table(records_stage3: List, final_total: float) -> str:
+    segment_prioritaire = [r for r in records_stage3 if r.effectif in (4, 5)]
+    segment_secondaire = [r for r in records_stage3 if r.effectif not in (4, 5)]
+
+    def summarize(records_subset: List) -> Tuple[int, int, float]:
+        base = len(records_subset)
+        prod = len([r for r in records_subset if (r.production_estimee or 0) >= PRODUCTION_THRESHOLD])
+        final = prod * MINDSET_FACTOR
+        return base, prod, final
+
+    prior_base, prior_prod, prior_final = summarize(segment_prioritaire)
+    sec_base, sec_prod, sec_final = summarize(segment_secondaire)
+    total_base = prior_base + sec_base
+    total_prod = prior_prod + sec_prod
+    total_final = prior_final + sec_final
+
+    rows = [
+        ["Prioritaire (4-5)", format_int(prior_base), format_int(prior_prod), format_int(prior_final), "🔴 HAUTE"],
+        ["Secondaire (3, 6-10)", format_int(sec_base), format_int(sec_prod), format_int(sec_final), "🟠 MOYENNE"],
+        ["TOTAL 3-10", format_int(total_base), format_int(total_prod), format_int(total_final), "-"]
+    ]
+    return table_markdown(["Segment", "TAM Base", "TAM Prod", "TAM Final", "Priorité"], rows)
+
+def resolve_region_name(code: int) -> str:
+    if code in REGION_NAMES:
+        return REGION_NAMES[code]
+    if code == 905:
+        return "Autres DOM-TOM"
+    if code is None:
+        return "Non renseigné"
+    return str(code)
+
+
+def build_region_table(records_stage3: List, final_total: float) -> str:
+    region_counts: Dict[int, int] = Counter(r.region_code for r in records_stage3)
+    rows = []
+    for code, count in sorted(region_counts.items(), key=lambda item: item[1], reverse=True):
+        prod = count  # 100% production
+        final = prod * MINDSET_FACTOR
+        pct = final / final_total if final_total else 0.0
+        name = resolve_region_name(code)
+        rows.append([
+            name,
+            format_int(count),
+            format_int(prod),
+            format_int(final),
+            format_percent(pct, 1),
+        ])
+    rows.append(["TOTAL", format_int(sum(region_counts.values())), format_int(sum(region_counts.values())), format_int(final_total), "100.0%"])
+    return table_markdown(["Région", "TAM Base", "TAM Prod", "TAM Final", "% national"], rows)
+
+def load_macro_priorities() -> Dict[str, str]:
+    path = os.path.join("analysis_outputs", "specialites_analysis.md")
+    priorities: Dict[str, str] = {}
+    if not os.path.exists(path):
+        return priorities
+    capture = False
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip().startswith("## Tableau 4"):
+                capture = True
+                continue
+            if capture:
+                if line.strip().startswith("## "):
+                    break
+                if not line.strip().startswith("|") or "---" in line:
+                    continue
+                parts = [part.strip() for part in line.strip().strip("|").split("|")]
+                if len(parts) < 6 or parts[0] == "Macro-thème":
+                    continue
+                theme = parts[0]
+                priority = parts[5]
+                priorities[theme] = priority
+    return priorities
+
+def build_macro_table(records_stage3: List, final_total: float) -> str:
+    priorities = load_macro_priorities()
+    macro_counts: Dict[str, int] = Counter(r.macro_theme for r in records_stage3)
+    rows = []
+    for theme in MACRO_THEMES:
+        count = macro_counts.get(theme, 0)
+        prod = count
+        final = prod * MINDSET_FACTOR
+        pct = final / final_total if final_total else 0.0
+        priority = priorities.get(theme, "-")
+        rows.append([
+            theme,
+            format_int(final),
+            format_percent(pct, 1),
+            priority if priority else "-",
+        ])
+    return table_markdown(["Macro-thème", "TAM Final", "% total", "Priorité marketing"], rows)
+
+def build_penetration_table(final_total: float) -> str:
+    goals = [
+        ("50K€/mois", 167),
+        ("100K€/mois", 334),
+        ("150K€/mois", 502),
+        ("200K€/mois", 669),
+    ]
+    rows = []
+    for label, clients in goals:
+        rate = clients / final_total if final_total else 0.0
+        if rate <= 0.03:
+            verdict = "✅ Réaliste"
+        elif rate <= 0.05:
+            verdict = "⚠️ Ambitieux"
+        elif rate <= 0.08:
+            verdict = "⚠️ Difficile"
+        else:
+            verdict = "❌ Hors benchmark"
+        rows.append([
+            label,
+            format_int(clients),
+            format_int(final_total),
+            format_percent(rate, 2),
+            verdict,
+        ])
+    return table_markdown(["Objectif", "Clients nécessaires", "TAM Final", "Taux pénétration", "Faisabilité"], rows)
+
+def build_scenarios_table(final_total: float) -> str:
+    if final_total >= 3000:
+        rows = [["Actuel", "Aucun", format_int(0), format_int(final_total), "Impact limité"]]
+    else:
+        # Placeholder scenario expansion (not triggered here)
+        rows = []
+    return table_markdown(["Option", "Ajustement", "TAM additionnel", "TAM Final", "Impact"], rows)
+
+def compute_top_segments(records_stage3: List) -> List[Tuple[str, float]]:
+    combo_counts: Dict[Tuple[str, int, str], int] = Counter()
+    for rec in records_stage3:
+        if rec.effectif not in (4, 5):
+            continue
+        region = resolve_region_name(rec.region_code)
+        theme = rec.macro_theme
+        combo_counts[(region, rec.effectif, theme)] += 1
+    if not combo_counts:
+        return []
+    top_items = combo_counts.most_common(3)
+    results = []
+    for (region, effectif, theme), count in top_items:
+        final = count * MINDSET_FACTOR
+        results.append((f"{region} + {effectif} form + {theme}", final))
+    return results
+
+def write_csv(records_stage3: List):
+    import csv
+    aggregated: Dict[Tuple[str, int, str], int] = Counter()
+    for rec in records_stage3:
+        region = resolve_region_name(rec.region_code)
+        effectif = rec.effectif or 0
+        theme = rec.macro_theme
+        aggregated[(region, effectif, theme)] += 1
+    with open(OUTPUT_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["region", "effectif", "macro_theme", "tam_base", "tam_final"])
+        for (region, effectif, theme), count in sorted(aggregated.items()):
+            writer.writerow([
+                region,
+                effectif,
+                theme,
+                count,
+                round(count * MINDSET_FACTOR, 2),
+            ])
+
+def main():
+    records = load_records()
+    funnel, stages = build_stage_funnel(records)
+    stage3 = stages["stage3"]
+    final_total = stages["final_total"]
+    lines: List[str] = []
+
+    # Table 1
+    rows = []
+    for label, count, pct_base, pct_prev in funnel:
+        rows.append([
+            label,
+            format_int(count),
+            format_percent(pct_base, 2),
+            format_percent(pct_prev, 2),
+        ])
+    lines.append("### Tableau 1 : Entonnoir TAM complet")
+    lines.append(table_markdown(["Étape", "OF", "% base", "% précédent"], rows))
+    lines.append("")
+
+    # Table 2
+    lines.append("### Tableau 2 : Comparaison TAM théorique vs réel")
+    lines.append(build_comparison_table(len(stage3), len(stage3), final_total))
+    lines.append("")
+
+    # Table 3
+    lines.append("### Tableau 3 : TAM segmenté")
+    lines.append(build_segment_table(stage3, final_total))
+    lines.append("")
+
+    # Table 4
+    lines.append("### Tableau 4 : TAM Final répartition géographique")
+    lines.append(build_region_table(stage3, final_total))
+    lines.append("")
+
+    # Table 5
+    lines.append("### Tableau 5 : TAM Final par domaine")
+    lines.append(build_macro_table(stage3, final_total))
+    lines.append("")
+
+    # Table 6
+    lines.append("### Tableau 6 : Taux pénétration objectifs")
+    lines.append(build_penetration_table(final_total))
+    lines.append("")
+
+    # Table 7
+    lines.append("### Tableau 7 : Options élargissement TAM")
+    lines.append(build_scenarios_table(final_total))
+    lines.append("")
+
+    # Synthèse sections
+    lines.append("## Synthèse")
+    tam_final_int = int(round(final_total))
+    tam_prod = len(stage3)
+    lines.append(f"TAM FINAL QALIA : {format_int(tam_final_int)} OF")
+    lines.append("")
+    lines.append("Entonnoir complet :")
+    for label, count, pct_base, _ in funnel:
+        lines.append(f"- {label} : {format_int(count)} ({format_percent(pct_base, 2)})")
+    lines.append("")
+    doc_final = 5167
+    diff_pct = (tam_final_int - doc_final) / doc_final * 100 if doc_final else 0.0
+    lines.append(f"vs Document 1 théorique (5 167) : {diff_pct:+.1f}%")
+    lines.append("")
+
+    lines.append("### Validation Avatar")
+    lines.append("AVATAR V1 : ✅ VALIDÉ" if tam_final_int >= 3000 else "AVATAR V1 : ❌ INVALIDÉ")
+    lines.append("")
+    lines.append("Hypothèses validées :")
+    lines.append("- 3-10 formateurs : ✅ {0} OF".format(format_int(len(stages["stage1"]))))
+    lines.append("- Qualiopi + actifs : ✅ {0} OF".format(format_int(len(stage3))))
+    lines.append("- Production 60% : ❌ 100% réel")
+    lines.append("- Sweet spot : 3-10 formateurs")
+    lines.append("")
+    lines.append("TAM Final :")
+    lines.append(f"- {format_int(tam_final_int)} OF (+{diff_pct:.1f}% vs doc)")
+    lines.append("")
+
+    lines.append("### Objectif 150K€ faisabilité")
+    rate_150 = 502 / final_total if final_total else 0.0
+    lines.append(f"OBJECTIF 150K€/MOIS : 502 clients → {format_percent(rate_150, 2)} du TAM")
+    if rate_150 <= 0.03:
+        horizon = "M6 : ✅ Atteignable | M12 : ✅ Réaliste | M18 : ✅ Très réaliste"
+    elif rate_150 <= 0.08:
+        horizon = "M6 : ⚠️ Très difficile | M12 : ✅ Réaliste | M18 : ✅ Très réaliste"
+    else:
+        horizon = "M6 : ❌ Peu réaliste | M12 : ⚠️ Ambitieux | M18 : ✅ Très réaliste"
+    lines.append(f"FAISABILITÉ : {horizon}")
+    lines.append("")
+    lines.append("### Segments prioritaires")
+    top_segments = compute_top_segments(stage3)
+    total_share = sum(final for _, final in top_segments)
+    share_pct = total_share / final_total if final_total else 0.0
+    lines.append(f"TOP 3 SEGMENTS (représentent {format_percent(share_pct, 1)} TAM Final) :")
+    for idx, (label, final) in enumerate(top_segments, start=1):
+        lines.append(f"{idx}. [{label}] : {format_int(final)} OF")
+    lines.append("")
+
+    os.makedirs(os.path.dirname(OUTPUT_MD), exist_ok=True)
+    with open(OUTPUT_MD, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+    write_csv(stage3)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `prompt18_tam_final.py` to consolidate TAM filters, compute production coverage, and prepare markdown/csv exports
- generate `analysis_outputs/prompt18_tam_final.md` with the full funnel, regional/macro segmentation, and business feasibility tables
- export `analysis_outputs/prompt18_tam_final.csv` containing TAM final volumes by region, effectif, and macro theme

## Testing
- python prompt18_tam_final.py

------
https://chatgpt.com/codex/tasks/task_e_68df4c94ac5c833181776e40c76e12ff